### PR TITLE
Updated documentation for Kubernetes DNS install

### DIFF
--- a/xml/deployment_additional.xml
+++ b/xml/deployment_additional.xml
@@ -17,9 +17,9 @@
  </info>
  <para>
   After you deploy your cluster you may want to install and use other software
-  that by default are not shipped with &productname;. This chapter gives you
+  that is not shipped with &productname; by default. This chapter gives you
   detailed instructions how to deploy e.g. the &kube; dashboard or how to set
-  up a DNS server.
+  up &kube; DNS for service discovery.
  </para>
  <sect1 xml:id="installing.kube.dashboard">
   <title>Installing &kube; Dashboard</title>
@@ -66,31 +66,23 @@
   </procedure>
  </sect1>
  <sect1 xml:id="installing.dns">
-  <title>Installing DNS Server</title>
+  <title>Installing &kube; DNS</title>
 
   <para>
-   Even though internal DNS server is essential for proper function of
-   &admin_node; and &kmaster;, it is not deployed automatically and you have to
-   deploy it manually. To install the DNS server, run the following command:
+   &kube; DNS is required if you intend to use DNS for service discovery
+   in your &kube; cluster. &kube; DNS is not deployed automatically
+   upon cluster provisioning and needs to be installed manually. In order to
+   install &kube; DNS, run the following command:
   </para>
 
-<screen>kubectl apply -f https://raw.githubusercontent.com/SUSE/caasp-services/master/contrib/addons/kubedns/dns.yaml</screen>
+  <screen>kubectl apply -f https://raw.githubusercontent.com/SUSE/caasp-services/master/contrib/addons/kubedns/dns.yaml</screen>
 
   <para>
-   After the command finishes, SSH to each
-   <emphasis role="bold">&kworker;</emphasis> and to the
-   <literal>KUBELET_ARGS</literal> section of the
-   <filename>/etc/kubernetes/kubelet</filename> file add the following entries
-   according to your system:
+   After &kube; DNS has been installed, you will be able to resolve pods
+   and services using their names from within the &kube; cluster. To
+   construct the fully qualified domain name for a pod or service, use
+   '.cluster.local' as the cluster domain suffix.
   </para>
 
-<screen>--cluster-dns=172.21.0.2 \
---cluster-domain=cluster.local \</screen>
-
-  <para>
-   On each &kworker; run the following:
-  </para>
-
-<screen>rckubelet restart</screen>
  </sect1>
 </chapter>


### PR DESCRIPTION
Updated the CaaSP documentation to reflect that Kubernetes DNS is
needed for service discovery. Also updated the list of steps required
to install Kubernetes DNS.