### PR TITLE
Added table of open ports to installation guide. (BSC#1043784)

### DIFF
--- a/xml/deployment_installation.xml
+++ b/xml/deployment_installation.xml
@@ -60,8 +60,8 @@
     <itemizedlist mark="bullet" spacing="normal">
      <listitem>
       <para>
-       In order to communicate without interruptions, all nodes should to be on
-       the same network.
+       In order to communicate without interruptions, all nodes should be on the
+       same network.
       </para>
      </listitem>
      <listitem>
@@ -219,7 +219,7 @@
             <literal>etcd</literal> control </para>
           </entry>
           <entry>
-           <para> For peer-to-peer etcd traffic </para>
+           <para> For peer-to-peer <literal>etcd</literal> traffic </para>
           </entry>
          </row>
          <row>
@@ -272,7 +272,7 @@
             <literal>etcd</literal> control </para>
           </entry>
           <entry>
-           <para> For peer-to-peer etcd traffic </para>
+           <para> For peer-to-peer <literal>etcd</literal> traffic </para>
           </entry>
          </row>
          <row>

--- a/xml/deployment_installation.xml
+++ b/xml/deployment_installation.xml
@@ -83,7 +83,239 @@
        </para>
       </important>
      </listitem>
+     <listitem>
+      <para>
+       In a &productname; cluster, internal TCP/IP ports are managed using
+       <literal>iptables</literal> controlled by <literal>Salt</literal>
+       and so need not be manually configured. However, for reference and
+       for environments where there are existing security policies, the 
+       following are the standard ports in use.
+      </para>
+      <table xml:id="sec.caasp.installquick.ports">
+       <title>Node types and open ports</title>
+       <tgroup cols="6">
+        <thead>
+         <row>
+          <entry>
+           <para> Node </para>
+          </entry>
+          <entry>
+           <para> Port </para>
+          </entry>
+          <entry>
+           <para> Internal / External </para>
+          </entry>
+          <entry>
+           <para> Open after orchestration </para>
+          </entry>
+          <entry>
+           <para> Description </para>
+          </entry>
+          <entry>
+           <para> Notes </para>
+          </entry>
+         </row>
+        </thead>
+        <tbody>
+         <row>
+          <entry>
+           <para> All machines </para>
+          </entry>
+          <entry>
+           <para> 22 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> ssh </para>
+          </entry>
+          <entry>
+           <para> Useful but not essential </para>
+          </entry>
+         </row>
+         <row>
+          <entry morerows="3" valign="middle">
+           <para> Admin </para>
+          </entry>
+          <entry>
+           <para> 80 </para>
+          </entry>
+          <entry>
+           <para> External </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> HTTP </para>
+          </entry>
+          <entry/>
+         </row>
+         <row>
+          <entry>
+           <para> 443 </para>
+          </entry>
+          <entry>
+           <para> External </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> HTTPS </para>
+          </entry>
+          <entry/>
+         </row>
+         <row>
+          <entry>
+           <para> 2379 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para>
+            <literal>etcd</literal> discovery </para>
+          </entry>
+          <entry/>
+         </row>
+         <row>
+          <entry>
+           <para> 4505 - 4506 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> Salt </para>
+          </entry>
+          <entry/>
+         </row>
+         <row>
+          <entry morerows="2" valign="middle">
+           <para> Masters </para>
+          </entry>
+          <entry>
+           <para> 2380 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> Yes </para>
+          </entry>
+          <entry>
+           <para>
+            <literal>etcd</literal> control </para>
+          </entry>
+          <entry>
+           <para> For peer-to-peer etcd traffic </para>
+          </entry>
+         </row>
+         <row>
+          <entry>
+           <para> 4789 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> VXLAN traffic </para>
+          </entry>
+          <entry>
+           <para> Used by Flannel </para>
+          </entry>
+         </row>
+         <row>
+          <entry>
+           <para> 6443 </para>
+          </entry>
+          <entry>
+           <para> Both </para>
+          </entry>
+          <entry>
+           <para> Yes </para>
+          </entry>
+          <entry>
+           <para> &kube; API server </para>
+          </entry>
+          <entry/>
+         </row>
+         <row>
+          <entry morerows="2" valign="middle">
+           <para> Workers </para>
+          </entry>
+          <entry>
+           <para> 2380 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> Yes </para>
+          </entry>
+          <entry>
+           <para>
+            <literal>etcd</literal> control </para>
+          </entry>
+          <entry>
+           <para> For peer-to-peer etcd traffic </para>
+          </entry>
+         </row>
+         <row>
+          <entry>
+           <para> 4789 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> VXLAN traffic </para>
+          </entry>
+          <entry>
+           <para> Used by Flannel </para>
+          </entry>
+         </row>
+         <row>
+          <entry>
+           <para> 10250 </para>
+          </entry>
+          <entry>
+           <para> Internal </para>
+          </entry>
+          <entry>
+           <para> No </para>
+          </entry>
+          <entry>
+           <para> Kubelet </para>
+          </entry>
+          <entry/>
+         </row>
+        </tbody>
+       </tgroup>
+      </table>
+     </listitem>
     </itemizedlist>
+    <para>
+     When some additional ingress mechanism is used, additional ports 
+     would also be open.
+    </para>
    </sect3>
    <sect3 xml:id="sec.caasp.installquick.limits">
     <title>Limitations</title>


### PR DESCRIPTION
# Table of ports

Added a table with a list of open ports to the Networking section of the deployment guide. 

Restructured the table from previous branch:

* merged header fields across multiple rows
* replaced empty entries with <entry/> tag
* fixed indentation
* modified XML ID to conform to deployment guide convention
