### PR TITLE
Remove remaining mention of ``rebootmgr'' command

### DIFF
--- a/xml/deployment_cluster_administration.xml
+++ b/xml/deployment_cluster_administration.xml
@@ -448,15 +448,6 @@ roleRef:
     by issuing the command:
    </para>
 <screen><command>systemctl</command> <option>--now disable transactional-update.timer</option></screen>
-   <para>
-    Automatic reboot can also be disabled; use either of the
-    commands:
-   </para>
-<screen><command>systemctl --now disable rebootmgr</command></screen>
-   <para>
-    or
-   </para>
-<screen><command>rebootmgrctl</command> <option>set-strategy off</option></screen>
   </sect2>
  </sect1>
  <sect1 xml:id="ptf.handling">


### PR DESCRIPTION
I missed these lines previously. Now removed. 

It's a small change -- if it looks OK, then please just hit the merge button, and I can close a bug that should not have got this old.