### PR TITLE
Change package name of TFTP server as requested in BSC #1094654

### DIFF
--- a/xml/deployment_installation.xml
+++ b/xml/deployment_installation.xml
@@ -1033,8 +1033,8 @@
    <para>
     You can directly use the <literal>initrd</literal> and
     <literal>linux</literal> files from your install media, or install the
-    package <package>tftpboot-installation-CAASP-1.0</package> on the TFTP
-    server. The package provides the required <literal>initrd</literal> and
+    package <package>tftpboot-installation-CAASP-2.0-x86_64</package> on the
+    TFTP server. The package provides the required <literal>initrd</literal> and
     <literal>linux</literal> files in the <filename>/srv/tftpboot/</filename>
     directory. You need to modify the paths used in the &sle; 12 Deployment
     Guide to correctly point to the files provided by the package.


### PR DESCRIPTION
See:

https://bugzilla.suse.com/show_bug.cgi?id=1094654

I've changed the package name as requested in the bug. It's a very small change. I also rewrapped it and the following line.

If this looks correct, please go ahead and merge it into maintenance/caasp2.

