### PR TITLE
Add missing space to paragraph

### DIFF
--- a/xml/deployment_about.xml
+++ b/xml/deployment_about.xml
@@ -288,7 +288,7 @@
    <para>
     The &admin_node; manages the cluster and runs several applications required
     for proper functioning of the cluster. Because it is integral to the 
-    operation of &productname;,the &admin_node; must have a fully-qualified 
+    operation of &productname;, the &admin_node; must have a fully-qualified 
     domain name (FQDN) which can be resolved from outside the cluster.  
    </para>
    <para>


### PR DESCRIPTION
The automatic replacement for the product string wasn't spaced correctly and looked bad in the flowing text.