### PR TITLE
Add ``enabled: true'' line to NTP config § of cloud-init example

### DIFF
--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -489,7 +489,7 @@ resolv_conf:
      three NTP servers during the first boot and the NTP service is enabled and
      started:
     </para>
-    <screen>ntp:
+<screen>ntp:
   enabled: true
   servers:
     - ntp1.example.com
@@ -504,7 +504,7 @@ runcmd:
      You can use the file to set the &sminion; and its communication with the
      &smaster;.
     </para>
-    <screen>salt_minion:
+<screen>salt_minion:
   conf:
     master: saltmaster.example.com
 

--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -489,16 +489,14 @@ resolv_conf:
      three NTP servers during the first boot and the NTP service is enabled and
      started:
     </para>
-    <screen>
-ntp:
+    <screen>ntp:
   enabled: true
   servers:
     - ntp1.example.com
     - ntp2.example.com
     - ntp3.example.com
 runcmd:
-  - /usr/bin/systemctl enable --now ntpd
-    </screen>
+  - /usr/bin/systemctl enable --now ntpd</screen>
    </sect3>
    <sect3 xml:id="user-data.config.salt.minion">
     <title>&sminion; Configuration</title>
@@ -506,8 +504,7 @@ runcmd:
      You can use the file to set the &sminion; and its communication with the
      &smaster;.
     </para>
-    <screen>
-salt_minion:
+    <screen>salt_minion:
   conf:
     master: saltmaster.example.com
 
@@ -519,8 +516,7 @@ salt_minion:
   private_key: |
     -----BEGIN RSA PRIVATE KEY-----
     XXX
-   -----END RSA PRIVATE KEY-----
-    </screen>
+   -----END RSA PRIVATE KEY-----</screen>
    </sect3>
    <sect3 xml:id="caasp.roles.assigment">
     <title>Assigning Roles to the Cluster Nodes</title>

--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -489,13 +489,16 @@ resolv_conf:
      three NTP servers during the first boot and the NTP service is enabled and
      started:
     </para>
-<screen>ntp:
+    <screen>
+ntp:
+  enabled: true
   servers:
     - ntp1.example.com
     - ntp2.example.com
     - ntp3.example.com
 runcmd:
-  - /usr/bin/systemctl enable --now ntpd</screen>
+  - /usr/bin/systemctl enable --now ntpd
+    </screen>
    </sect3>
    <sect3 xml:id="user-data.config.salt.minion">
     <title>&sminion; Configuration</title>
@@ -503,7 +506,8 @@ runcmd:
      You can use the file to set the &sminion; and its communication with the
      &smaster;.
     </para>
-<screen>salt_minion:
+    <screen>
+salt_minion:
   conf:
     master: saltmaster.example.com
 
@@ -515,7 +519,8 @@ runcmd:
   private_key: |
     -----BEGIN RSA PRIVATE KEY-----
     XXX
-   -----END RSA PRIVATE KEY-----</screen>
+   -----END RSA PRIVATE KEY-----
+    </screen>
    </sect3>
    <sect3 xml:id="caasp.roles.assigment">
     <title>Assigning Roles to the Cluster Nodes</title>


### PR DESCRIPTION
Fixes P1 bug caused by update from cloudinit 17.x to 18.x 

https://bugzilla.suse.com/show_bug.cgi?id=1084509

