### PR TITLE
Remove mention of installing guest additions

### DIFF
--- a/xml/deployment_sysreqs.xml
+++ b/xml/deployment_sysreqs.xml
@@ -196,13 +196,17 @@
       </listitem>
      </itemizedlist>
      <para>
-      When building a cluster from hypervisor VMs, &suse; recommends building
+      When building a cluster from virtual machines, &suse; recommends building
       nodes from pre-installed disk images, rather than installing new instances
       from an ISO image. 
      </para>
      <para>
-      The pre-installed VM images come with the relevant hypervisor's guest
-      tools pre-installed (where this is applicable).
+      Virtual-disk images are available for Hyper-V, KVM, OpenStack, VMware,
+      and Xen. 
+     </para>
+     <para>
+      These VM images include the relevant hypervisor's guest additions or tools
+      (where this is applicable).
      </para>
      <note>
       <title>&vmware; Memory Ballooning</title>

--- a/xml/deployment_sysreqs.xml
+++ b/xml/deployment_sysreqs.xml
@@ -202,9 +202,7 @@
      </para>
      <para>
       The pre-installed VM images come with the relevant hypervisor's guest
-      tools pre-installed (where this is applicable). It is possible to install
-      these manually, but due to the read-only root filesystem, this is not a
-      trivial task.
+      tools pre-installed (where this is applicable).
      </para>
      <note>
       <title>&vmware; Memory Ballooning</title>


### PR DESCRIPTION
As requested in bug comment. 

I can't comply with the full request (i.e. link to § on package installation) because we don't have one, but this removes the negative statement about installing guest additions being difficult.

I think this also makes a case for copying the whole sysreqs § into the QS guide as well. Yes a standalone file would be nicer but it's difficult because of the entities. For now a copy-paste-edit may have to do, I think. 

