### PR TITLE
Fix typo "large-scaled" → "large-scale" (BSC#1099696)

### DIFF
--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -23,7 +23,7 @@
    For security and stability reasons, the operating system and application
    should always be up-to-date. While with a single machine you can keep the
    system up-to-date quite easily by running several commands, in a
-   large-scaled cluster the update process can become a real burden. Thus
+   large-scale cluster the update process can become a real burden. Thus
    transactional automatic updates have been introduced. Transactional updates
    can be characterized as follows:
   </para>


### PR DESCRIPTION
Fix a single-letter typo. 