### PR TITLE
Add Troubleshooting section to Admin Guide

### DIFF
--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -857,8 +857,7 @@ worker-4   Ready,SchedulingDisabled   &lt;none>    21h       v1.9.8</screen>
    following on the &admin_node;:
   </para>
 <screen>&prompt.root;<command>echo "worker_threads: 20" > /etc/caasp/salt-master-custom.conf</command>
-&prompt.root;<command>saltid=$(docker ps | grep salt-master | awk '{print $1}')</command>
-&prompt.root;<command>docker kill $saltid</command></screen>
+&prompt.root;<command>docker restart $(docker ps | grep salt-master | awk '{print $1}')</command></screen>
   <para>
    Salt master will be automatically restarted by kubelet.
   </para>

--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -763,4 +763,110 @@ worker-4   Ready,SchedulingDisabled   &lt;none>    21h       v1.9.8</screen>
    </para>
   </sect2>
  </sect1>
+
+ <sect1 xml:id="sec.admin.scale_cluster">
+  <title>Scaling the Cluster</title>
+  <para>
+   The default maximum number of nodes in a cluster is 40. The Salt
+   Master configuration needs to be adjusted to handle installation and
+   updating a of larger cluster:
+  </para>
+  <table>
+   <title>Node Count and Salt Worker Threads</title>
+   <tgroup cols="2">
+    <thead>
+     <row>
+      <entry>
+       <para>
+        Nodes
+       </para>
+      </entry>
+      <entry>
+       <para>
+        Salt Worker Threads
+       </para>
+      </entry>
+     </row>
+    </thead>
+    <tbody>
+     <row>
+      <entry>
+       <para>
+        &gt;40
+       </para>
+      </entry>
+      <entry>
+       <para>
+        20
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        &gt;60
+       </para>
+      </entry>
+      <entry>
+       <para>
+        30
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        &gt;75
+       </para>
+      </entry>
+      <entry>
+       <para>
+        40
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        &gt;85
+       </para>
+      </entry>
+      <entry>
+       <para>
+        50
+       </para>
+      </entry>
+     </row>
+     <row>
+      <entry>
+       <para>
+        &gt;95
+       </para>
+      </entry>
+      <entry>
+       <para>
+        60
+       </para>
+      </entry>
+     </row>
+    </tbody>
+   </tgroup>
+  </table>
+  <para>
+   To change the variable in the Salt Master configuration, run the
+   following on the &admin_node;:
+  </para>
+<screen>&prompt.root;<command>echo "worker_threads: 20" > /etc/caasp/salt-master-custom.conf</command>
+&prompt.root;<command>saltid=$(docker ps | grep salt-master | awk '{print $1}')</command>
+&prompt.root;<command>docker kill $saltid</command></screen>
+  <para>
+   Salt master will be automatically restarted by kubelet.
+  </para>
+  <para>
+   Following bootstrapping failure, you can check if Salt
+   worker_threads is too low.
+  </para>
+<screen>&prompt.root;<command>docker logs $(docker ps | grep salt-master | \
+    awk '{print $1}') 2>&amp;1 | grep -i worker_threads</command></screen>
+ </sect1>
 </chapter>

--- a/xml/admin_software.xml
+++ b/xml/admin_software.xml
@@ -302,7 +302,112 @@
     </step>
    </procedure>
   </sect2>
-  
+
+  <sect2 xml:id="sec.admin.software.transactional-updates.recovering">
+   <title>Recovering from Failed Updates</title>
+   <para>
+    Velum notifies you about failed updates. If the update failed,
+    there are several things that can be the cause. The following list
+    provides an overview of things to check. For general information
+    about troubleshooting, read <xref
+    linkend="sec.admin.troubleshooting.overview" />.
+   </para>
+   <warning>
+    <title>Do Not Interfere with Transactional Updates</title>
+    <para>
+     Do not manually interfere with transactional updates. Do so only
+     if you are requested to do so by &suse; support.
+    </para>
+    <para>
+     For details, see <xref
+     linkend="sec.admin.software.transactional-updates.command" />.
+    </para>
+   </warning>
+   <variablelist>
+    <varlistentry>
+     <term>Stopping Services and Reboot</term>
+     <listitem>
+      <para>
+       Velum uses &salt; to stop all services and reboot the node. Salt
+       also takes care of adjusting configuration. Check the logs of
+       the &salt; master and minions for error messages. For details,
+       see <emphasis>Salt Logging</emphasis><!--<xref
+       linkend="sec.admin.logging.salt.master" /> and <xref
+       linkend="sec.admin.logging.salt.minion" /> -->.
+      </para>
+      <remark>
+       Enable xrefs once https://github.com/SUSE/doc-caasp/pull/78 is
+       merged.
+      </remark>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Installing Updates</term>
+     <listitem>
+      <para>
+       Updates are installed once a day but only applied after a reboot
+       is manually triggered. If the installation of updates fails,
+       Velum shows the message <literal>Update Failed</literal> as the
+       node's status. In this case, log in on the node and check
+       <filename>/var/log/transactional-update.log</filename> for
+       problems.
+      </para>
+     </listitem>
+    </varlistentry>
+    <varlistentry>
+     <term>Starting Services</term>
+     <listitem>
+      <para>
+       Finally, all services of the node are being restarted. Look
+       which services have failed by executing <command>systemctl
+       list-units --failed</command>. Then check the logs of failed
+       services.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+   <para>
+    The following procedure can help in some situations.
+   </para>
+   <procedure>
+    <step>
+     <para>
+      Reboot all nodes.
+     </para>
+<screen>&prompt.root.admin;<command>exec -it $(docker ps | grep salt-master | \
+    awk '{print $1}') salt '*' system.reboot</command></screen>
+    </step>
+    <step>
+     <para>
+      On the &admin_node; run
+     </para>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep salt-master | \
+    awk '{print $1}') salt "*" cmd.run "transactional-update cleanup reboot dup"</command></screen>
+    </step>
+    <step>
+     <para>
+      Reboot all nodes again.
+     </para>
+<screen>&prompt.root.admin;<command>exec -it $(docker ps | grep salt-master | \
+    awk '{print $1}') salt '*' system.reboot</command></screen>
+    </step>
+    <step>
+     <para>
+      Start the update with debug output.
+     </para>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep salt-master | \
+    awk '{print $1}') salt-run -l debug state.orchestrate orch.update</command></screen>
+    </step>
+    <step>
+     <para>
+      If there is any ongoing problem, look at all the &salt; grains of
+      all nodes in <filename>/etc/salt/grains</filename>. This file
+      contains the status if the update is ongoing, and is therefore
+      providing the "Update Retry" in Velum.
+     </para>
+    </step>
+   </procedure>
+  </sect2>
  </sect1>
  
  <sect1 xml:id="sec.admin.software.patch">

--- a/xml/admin_software.xml
+++ b/xml/admin_software.xml
@@ -340,45 +340,41 @@
  <screen>&prompt.root;<command>transactional-update reboot ptf remove <replaceable>RPM1 RPM2 &hellip;</replaceable></command></screen>
  </sect1>
  
- <sect1 xml:id="sec.admin.software.upgrade">
-  <title>Upgrade &productname;</title>
- <para>
-  As &productname; is constantly developed and improved, new versions get
-  released. You are strongly advised to upgrade to a supported release. These
-  upgrades may involve manual intervention.
- </para>
- <important>
-  <title>Service Window Required</title>
-  <para>
-   Upgrades may take some time, during which services may be degraded in
-   performance or completely unavailable. Please make sure to plan a service
-   window.
-  </para>
- </important>
- <procedure xml:id="pro.admin.upgrade.procedure">
-  <title>General Upgrade Procedure</title>
-  <step>
-   <para>
-    Upgrade the &admin_node;.
-   </para>
-  </step>
-  <step>
-   <para>
-    Manually perform additional upgrade steps of the &admin_node;. These steps
-    are version-specific and described in the following chapters.
-   </para>
-  </step>
-  <step>
-   <para>
-    Upgrade the cluster nodes through &dashboard;.
-   </para>
-  </step>
- </procedure>
-
- <sect2 xml:id="sec.admin.software.upgrade.caasp2">
+ <sect1 xml:id="sec.admin.software.upgrade_caasp2">
   <title>Upgrading from &productname; 2</title>
-    
-  <sect3 xml:id="sec.admin.software.upgrade.caasp2.prereq">
+  <para>
+   As &productname; is constantly developed and improved, new versions get
+   released. You are strongly advised to upgrade to a supported release. These
+   upgrades may involve manual intervention.
+  </para>
+  <important>
+   <title>Service Window Required</title>
+   <para>
+    Upgrades may take some time, during which services may be degraded in
+    performance or completely unavailable. Please make sure to plan a service
+    window.
+   </para>
+  </important>
+  <procedure xml:id="pro.admin.upgrade.procedure">
+   <title>General Upgrade Procedure</title>
+   <step>
+    <para>
+     Upgrade the &admin_node;.
+    </para>
+   </step>
+   <step>
+    <para>
+     Manually perform additional upgrade steps of the &admin_node;. These steps
+     are version-specific and described in the following chapters.
+    </para>
+   </step>
+   <step>
+    <para>
+     Upgrade the cluster nodes through &dashboard;.
+    </para>
+   </step>
+  </procedure>
+  <sect2 xml:id="sec.admin.software.upgrade_caasp2.prereq">
    <title>Ensure All &productname; v2 Updates Are Installed</title>
    <para>
     Before you start the upgrade procedure to &productname; v3, you must ensure
@@ -427,9 +423,9 @@ retcode:
     If the package version is <literal>0.3.11-3.15.1</literal> (or higher) you
     have the latest updates from the v2 channel installed.
    </para>
-  </sect3>
+  </sect2>
    
-   <sect3 xml:id="sec.admin.software.upgrade.caasp2.timer">
+   <sect2 xml:id="sec.admin.software.upgrade_caasp2.timer">
     <title>Disable Automatic <literal>transactional-update</literal></title>
     <para>
     To begin with the upgrade procedure, you first must disable the automatic
@@ -477,9 +473,9 @@ retcode:
      If you use &smtool; or &susemgr; for mirroring channels: Mirror the v3 channels on your server.
     </para>
    </important>
-  </sect3>
+  </sect2>
    
-   <sect3 xml:id="sec.admin.software.upgrade.caasp2.upgrade">
+   <sect2 xml:id="sec.admin.software.upgrade_caasp2.upgrade">
     <title>Performing The Upgrade Procedure</title>
     <para>
      In the next step you must run the update command across your nodes.
@@ -541,9 +537,9 @@ retcode:
      to the current working directory. This log file can be very helpful should
      any of the update operations fail.
     </para>
-   </sect3>
+   </sect2>
    
-   <sect3 xml:id="sec.admin.software.upgrade.caasp2.reboot">
+   <sect2 xml:id="sec.admin.software.upgrade_caasp2.reboot">
     <title>Reboot cluster nodes from &dashboard;</title>
     <para>
      To complete the procedure, you must reboot the cluster nodes. To do this 
@@ -568,9 +564,9 @@ retcode:
       </para>
      </step>
     </procedure>
-   </sect3>
+   </sect2>
   
-  <sect3 xml:id="sec.admin.software.upgrade.caasp2.troubleshooting">
+  <sect2 xml:id="sec.admin.software.upgrade_caasp2.troubleshooting">
    <title>Troubleshooting</title>
    <para>
     In case the upgrade fails, please perform the support data collection by 
@@ -578,8 +574,7 @@ retcode:
     resulting files including the <filename>transactional-update-migration.log</filename>
     to SUSE Support.
    </para>
-  </sect3>
- </sect2>
+  </sect2>
  </sect1>
  
  <sect1 xml:id="sec.admin.software.install">

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -64,6 +64,14 @@
   </para>
  </sect1>
 
+ <sect1 xml:id="sec.admin.troubleshooting.failed_update">
+  <title>Recovering from Failed Update</title>
+  <para>
+   See <xref
+   linkend="sec.admin.software.transactional-updates.recovering" />.
+  </para>
+ </sect1>
+
  <sect1 xml:id="sec.admin.troubleshooting.etcd">
   <title>Checking <literal>etcd</literal> Health</title>
   <para>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -82,9 +82,11 @@
    Use SSH to log into one of the cluster nodes, for example your first master.
    The following command provides an example for using <command>etcdctl</command>.
   </para>
-<screen>&prompt.root;<command>source /etc/sysconfig/etcdctl</command>
+<screen>&prompt.root;<command>set -a</command>
+ &prompt.root;<command>source /etc/sysconfig/etcdctl</command>
 &prompt.root;<command>etcdctl --endpoints $ETCDCTL_ENDPOINT --ca-file $ETCDCTL_CA_FILE \
-    --cert-file $ETCDCTL_CERT_FILE --key-file $ETCDCTL_KEY_FILE cluster-health</command></screen>
+    --cert-file $ETCDCTL_CERT_FILE --key-file $ETCDCTL_KEY_FILE cluster-health</command>
+&prompt.root;<command>etcdctl cluster-health</command></screen>
  </sect1>
 
  <sect1 xml:id="sec.admin.troubleshooting.velum_ptf">

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -74,12 +74,12 @@
    </step>
    <step>
     <para>
-     Check logs from Salt orchestration. If &productname; cluster
-     bootstrap fails in Velum, look into <command>salt-master</command>
-     orchestration logs by executing:
+     Convert the log into a human readable format and open it with
+     <command>less</command>.
     </para>
-<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep "salt-master" | awk '{print $1}') \
-    salt-run state.event pretty=True > salt-event.logs</command></screen>
+<screen>&prompt.root.admin;<command>/var/lib/supportutils-plugin-suse-caasp/debug-salt --json_output=salt.json \
+    --summary_output=summary.txt --text-status --no-color</command>
+&prompt.root.admin;<command>less summary.txt</command></screen>
    </step>
    <step>
     <para>
@@ -148,8 +148,6 @@
   </para>
 <screen>&prompt.root;<command>set -a</command>
 &prompt.root;<command>source /etc/sysconfig/etcdctl</command>
-&prompt.root;<command>etcdctl --endpoints $ETCDCTL_ENDPOINT --ca-file $ETCDCTL_CA_FILE \
-    --cert-file $ETCDCTL_CERT_FILE --key-file $ETCDCTL_KEY_FILE cluster-health</command>
 &prompt.root;<command>etcdctl cluster-health</command></screen>
  </sect1>
 
@@ -161,6 +159,13 @@
    when updates are started with Velum. To prevent this, execute the
    following procedure.
   </para>
+  <important>
+   <title>Locks Disable Updates for Package</title>
+   <para>
+    If a package is locked, it will no longer receive any updates until
+    the lock is released with <command>zypper rl</command>.
+   </para>
+  </important>
   <procedure>
    <step>
     <para>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -97,4 +97,102 @@
    linkend="sec.configuration.suseconnect.proxy" />.
   </para>
  </sect1>
+
+ <sect1 xml:id="sec.admin.troubleshooting.replace_certificates">
+  <title>Replacing TLS/SSL Certificates</title>
+  <para>
+   Sometimes certificates are not updated properly because they are
+   outdated. To replace outdated certificates, execute the following
+   procedure.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Use SSH  and log in on the &admin_node;.
+    </para>
+   </step>
+   <step>
+    <para>
+      Move the expired certs out of the way.
+    </para>
+    <screen>&prompt.root.admin;<command>mv /etc/pki/{velum,ldap,salt-api}.crt /root</command></screen>
+   </step>
+   <step>
+    <para>
+     Generate new certificates.
+    </para>
+<screen>&prompt.root.admin;<command>cd /etc/pki</command>
+&prompt.root.admin;<command>/usr/share/caasp-container-manifests/gen-certs.sh</command></screen>
+    <tip>
+     <title>Generating Additional Certificates</title>
+     <para>
+      To regenerate additional certificates, for example
+      <filename>/etc/pki/kubectl-client-cert.crt</filename>, add an
+      additional line at the end of the
+      <command>gen-certs.sh</command> script:
+     </para>
+<screen>&prompt.root.admin;<command>transactional-update shell</command>
+<prompt>transactional update #</prompt> <command>echo "gencert \"kubectl-client-cert\" \"kubectl-client-cert\" \
+    \"\$all_hostnames\" \"\$(ip_addresses)\"" >>/usr/share/caasp-container-manifests/gen-certs.sh</command>
+<prompt>transactional update # </prompt><command>/usr/share/caasp-container-manifests/gen-certs.sh</command>
+<prompt>transactional update # </prompt><command>exit</command></screen>
+    </tip>
+   </step>
+   <step>
+    <para>
+     Use SSH and log in on a &master_node;.
+    </para>
+   </step>
+   <step>
+    <para>Backup and delete the dex-tls secret.</para>
+<screen>&prompt.root.master;<command>kubectl -n kube-system get secret dex-tls -o yaml > /root/dex-tls</command>
+&prompt.root.master;<command>kubectl -n kube-system delete secret dex-tls</command></screen>
+   </step>
+   <step>
+    <para>
+     On a master node, find and delete the Dex pods.
+    </para>
+    <important>
+     <para>
+      This prevents new authentications requests from succeeding.
+      However, the static credentials located on the master nodes will
+      continue to function.
+     </para>
+     <para>
+      The Dex pods will not restart by themselves until the dex-tls
+      secret is recreated.
+     </para>
+    </important>
+<screen>&prompt.root.master;<command>kubectl -n kube-system get pods | grep dex</command>
+&prompt.root.master;<command>kubectl -n kube-system delete pods <replaceable>DEX_POD1</replaceable> <replaceable>DEX_POD2</replaceable> <replaceable>DEX_POD3</replaceable></command></screen>
+   </step>
+   <step>
+    <para>
+     Manually run the salt orchestration on the &admin_node;. This may
+     take some time.
+    </para>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep salt-master | awk '{print $1}') \
+    bash -c "salt-run state.orchestrate orch.kubernetes" 2&amp;>1 > salt-run.log</command></screen>
+   </step>
+   <step>
+    <para>
+     Check the tail of <filename>salt-run.log</filename> to see if the
+     orchestration succeeded.
+    </para>
+    <screen>&prompt.root.admin;<command>tail -n 50 salt-run.log</command></screen>
+   </step>
+   <step>
+    <para>
+     On a master node, validate the dex pods are running.
+    </para>
+    <screen>&prompt.root.master;<command>kubectl -n kube-system get pods | grep dex</command></screen>
+   </step>
+   <step>
+    <para>
+     If you are not able to log in into Velum, reboot the &admin_node;.
+     Then test and validate that the cluster is still functional.
+    </para>
+   </step>
+  </procedure>
+ </sect1>
 </chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -64,6 +64,21 @@
   </para>
  </sect1>
 
+ <sect1 xml:id="sec.admin.troubleshooting.etcd">
+  <title>Checking <literal>etcd</literal> Health</title>
+  <para>
+   To work with <command>etcdctl</command>, you have to pass parameters
+   with paths to required certificates.
+  </para>
+  <para>
+   Use SSH to log into one of the cluster nodes, for example your first master.
+   The following command provides an example for using <command>etcdctl</command>.
+  </para>
+<screen>&prompt.root;<command>source /etc/sysconfig/etcdctl</command>
+&prompt.root;<command>etcdctl --endpoints $ETCDCTL_ENDPOINT --ca-file $ETCDCTL_CA_FILE \
+    --cert-file $ETCDCTL_CERT_FILE --key-file $ETCDCTL_KEY_FILE cluster-health</command></screen>
+ </sect1>
+
  <sect1 xml:id="sec.admin.troubleshooting.velum_ptf">
   <title>Locking Installed Program Temporary Fixes</title>
   <para>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -320,4 +320,54 @@
    </step>
   </procedure>
  </sect1>
+ <sect1 xml:id="sec.admin.troubleshooting.add_ca_cert">
+  <title>Fix the error <literal>x509: certificate signed by unknown authority</literal></title>
+  <para>
+   When interacting with &kube; you can run into the situation where your
+   existing configuration for the authentication has changed (cluster has been
+   rebuild, certificates have been switched.)
+  </para>
+  <para>
+   In such a case you might see an error message in the output of your CLI tool.
+  </para>
+<screen><literal>x509: certificate signed by unknown authority</literal>
+ </screen>
+ <para>
+  This message indicates that your current system does not know the Certificate
+  Authority (CA) that signed the SSL certificates used for encrypting the
+  communication to the cluster. You then need to add or update the Root CA
+  certificate in your local trust store.
+ </para>
+ <procedure>
+  <step>
+   <para>
+    Copy the Root CA certificate file into the trust anchors directory
+    <filename>/etc/pki/trust/anchors/</filename>.
+   </para>
+   <para>
+    Replace <literal>SUSE_CaaSP_CA.crt</literal> with the actual name of your
+    file.
+   </para>
+<screen>&prompt.user;<command>cp <replaceable>SUSE_CaaSP_CA.crt</replaceable> /etc/pki/trust/anchors/</command>
+   </screen>
+  </step>
+  <step>
+   <para>
+    Update the cache for known CA certificates.
+   </para>
+<screen>&prompt.user;<command>update-ca-certificates</command></screen>
+  </step>
+ </procedure>
+ <note>
+  <title>Operating system specific instructions</title>
+  <para>
+   The location of the trust store anchors directory or the command to refresh
+   the CA certificates cache might vary depending on your operating system.
+  </para>
+  <para>
+   Please consult the official documentation for your operating system to
+   find the respective alternatives.
+  </para>
+ </note>
+ </sect1>
 </chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -58,10 +58,74 @@
  </sect1>
 
  <sect1 xml:id="sec.admin.troubleshooting.failed_bootstrap">
-  <title>Recover from Failed Bootstrap</title>
+  <title>Debugging Failed Bootstrap</title>
   <para>
-   
+   If the bootstrapping as described in <xref
+   linkend="sec.deploy.install.bootstrap" /> fails, there are several
+   places to look for errors. The following procedure outlines where to
+   start debugging.
   </para>
+  <procedure>
+   <step>
+    <para>
+     Check the logs from Velum dashboard. Execute on the &admin_node;:
+    </para>
+    <screen>&prompt.root.admin;<command>docker logs $(docker ps | grep "velum-dashboard" | awk '{print $1}')</command></screen>
+   </step>
+   <step>
+    <para>
+     Check logs from Salt orchestration. If &productname; cluster
+     bootstrap fails in Velum, retry and look into
+     <command>salt-master</command> orchestration logs by executing:
+    </para>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep "salt-master" | awk '{print $1}') \
+    salt-run state.event pretty=True > salt-event.logs</command></screen>
+   </step>
+   <step>
+    <para>
+     Retry bootstrapping from &admin_node; console.
+    </para>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep salt-master | awk '{print $1}') \
+    salt-run -l debug state.orchestrate orch.kubernetes > salt-orchestration.logs</command></screen>
+   </step>
+   <step>
+    <para>
+     If the orchestration failed in late state, you can check if
+     <command>etcd</command> and the &kube; cluster is up and running.
+     Log in on a &master_node; and check if <command>etcd</command>
+     cluster is up and running.
+    </para>
+<screen>&prompt.root.master;<command>set -a</command>
+&prompt.root.master;<command>source /etc/sysconfig/etcdctl</command>
+&prompt.root.master;<command>etcdctl member list</command>
+&prompt.root.master;<command>etcdctl endpoint health</command>
+&prompt.root.master;<command>etcdctl endpoint status</command>
+&prompt.root.master;<command>journalctl -u etcd</command></screen>
+    <para>
+     Check if &kube; cluster is up and running.
+    </para>
+<screen>&prompt.root.master;<command>kubectl get nodes</command>
+&prompt.root.master;<command>kubectl cluster-info</command>
+&prompt.root.master;<command>journalctl -u kubelet</command>
+&prompt.root.master;<command>journalctl -u kube-apiserver</command>
+&prompt.root.master;<command>journalctl -u kube-scheduler</command>
+&prompt.root.master;<command>journalctl -u kube-controller-manager</command></screen>
+   </step>
+   <step>
+    <para>
+     Collect all relevant logs with <command>supportconfig</command> on
+     the &master_node; and &admin_node;.
+    </para>
+<screen>&prompt.root.admin;<command>supportconfig</command>
+&prompt.root.admin;<command>tar -xvjf /var/log/nts_*.tbz</command>
+&prompt.root.admin;<command>cd nts*</command>
+&prompt.root.admin;<command>cat etcd.txt kubernetes.txt salt-minion.txt</command></screen>
+<screen>&prompt.root.master;<command>supportconfig</command>
+&prompt.root.master;<command>tar -xvjf /var/log/nts_*.tbz</command>
+&prompt.root.master;<command>cd nts*</command>
+&prompt.root.master;<command>cat etcd.txt kubernetes.txt salt-minion.txt</command></screen>
+   </step>
+  </procedure>
  </sect1>
 
  <sect1 xml:id="sec.admin.troubleshooting.failed_update">
@@ -83,7 +147,7 @@
    The following command provides an example for using <command>etcdctl</command>.
   </para>
 <screen>&prompt.root;<command>set -a</command>
- &prompt.root;<command>source /etc/sysconfig/etcdctl</command>
+&prompt.root;<command>source /etc/sysconfig/etcdctl</command>
 &prompt.root;<command>etcdctl --endpoints $ETCDCTL_ENDPOINT --ca-file $ETCDCTL_CA_FILE \
     --cert-file $ETCDCTL_CERT_FILE --key-file $ETCDCTL_KEY_FILE cluster-health</command>
 &prompt.root;<command>etcdctl cluster-health</command></screen>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -77,10 +77,24 @@
   </para>
  </sect1>
 
-<sect1 xml:id="sec.admin.troubleshooting.rbac">
+ <sect1 xml:id="sec.admin.troubleshooting.rbac">
   <title>RBAC/PSP</title>
   <para>
 
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec.admin.troubleshooting.proxy">
+  <title>Using a Proxy Server with Authentication</title>
+  <para>
+   If you need to register the &admin_node; with &scc; over a proxy
+   server that requires authentication, it is not possible to specify
+   the configuration in <filename>/etc/sysconfig/proxy</filename>.
+  </para>
+  <para>
+   For information about setting authentication credentials and
+   connecting to &scc; with <command>SUSEConnect</command>, see <xref
+   linkend="sec.configuration.suseconnect.proxy" />.
   </para>
  </sect1>
 </chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -31,5 +31,31 @@
    xlink:href="https://www.suse.com/support/kb/?id=SUSE_CaaS_Platform"
    />.
   </para>
+  <para>
+   In case of problems, a detailed system report can be created with
+   the <command>supportconfig</command> command line tool. It will
+   collect information about the system such as: current kernel
+   version, hardware, installed packages, partition setup, and much
+   more. The result is a TAR archive of files. After opening a Service
+   Request (SR), you can upload the TAR archive to Global Technical
+   Support. It will help to locate the issue you reported and to assist
+   you in solving the problem. For details, see <link xlink:href=
+   "https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_adm_support.html"
+   />.
+  </para>
+  <para>
+   While resolving a technical difficulty with SUSE Support, you may
+   receive a so-called Program Temporary Fix (PTF). PTFs may be issued
+   for various packages as RPMs. For details about handling RPMs, see
+   <link xlink:href=
+   "https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_rpm.html"
+   />.
+  </para>
+  <para>
+   For details about how to contact &suse; support, refer to <link
+   xlink:href=
+   "https://www.suse.com/media/flyer/suse_customer_support_quick_reference_guide_flyer.pdf"
+   /> and <link xlink:href="https://www.suse.com/support/" />.
+  </para>
  </sect1>
 </chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -64,6 +64,43 @@
   </para>
  </sect1>
 
+ <sect1 xml:id="sec.admin.troubleshooting.velum_ptf">
+  <title>Locking Installed Program Temporary Fixes</title>
+  <para>
+   It can happen that <command>zypper</command> removes an installed
+   <emphasis>Program Temporary Fix</emphasis> (<emphasis>PTF</emphasis>)
+   when updates are started with Velum. To prevent this, execute the
+   following procedure.
+  </para>
+  <procedure>
+   <step>
+    <para>
+     Install the PTF manually.
+    </para>
+    <screen>&prompt.root;<command>transactional-update reboot <replaceable>PTF_FILE</replaceable>.rpm install
+</command></screen>
+   </step>
+   <step>
+    <para>
+     As soon as the node has restarted, verify that the RPM is installed.
+    </para>
+    <screen>&prompt.root;<command>rpm -qa | grep PTF</command></screen>
+   </step>
+   <step>
+    <para>
+     Create a <command>zypper</command> lock for this RPM.
+    </para>
+    <screen>&prompt.root;<command>zypper al <replaceable>PTF_PACKAGE_NAME</replaceable></command></screen>
+   </step>
+   <step>
+    <para>
+     Verify that the lock is created.
+    </para>
+    <screen>&prompt.root;<command>zypper ll</command></screen>
+   </step>
+  </procedure>
+ </sect1>
+
  <sect1 xml:id="sec.admin.troubleshooting.network_planning">
   <title>Network Planing and Reconfiguration</title>
   <para>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -153,10 +153,11 @@
      On a master node, find and delete the Dex pods.
     </para>
     <important>
+     <title>This Step Breaks Authentication</title>
      <para>
-      This prevents new authentications requests from succeeding.
-      However, the static credentials located on the master nodes will
-      continue to function.
+      Executing this step prevents new authentications requests from
+      succeeding. However, the static credentials located on the master
+      nodes will continue to function.
      </para>
      <para>
       The Dex pods will not restart by themselves until the dex-tls

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -46,16 +46,41 @@
   <para>
    While resolving a technical difficulty with SUSE Support, you may
    receive a so-called Program Temporary Fix (PTF). PTFs may be issued
-   for various packages as RPMs. For details about handling RPMs, see
-   <link xlink:href=
-   "https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_rpm.html"
-   />.
+   for various packages as RPMs. For details about handling PTFs, see
+   <xref linkend="sec.admin.software.patch" />.
   </para>
   <para>
    For details about how to contact &suse; support, refer to <link
    xlink:href=
    "https://www.suse.com/media/flyer/suse_customer_support_quick_reference_guide_flyer.pdf"
    /> and <link xlink:href="https://www.suse.com/support/" />.
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec.admin.troubleshooting.failed_bootstrap">
+  <title>Recover from Failed Bootstrap</title>
+  <para>
+   
+  </para>
+ </sect1>
+
+ <sect1 xml:id="sec.admin.troubleshooting.network_planning">
+  <title>Network Planing and Reconfiguration</title>
+  <para>
+   It is not possible to reconfigure the used IP ranges of &productname;
+   once the deployment is complete. Therefore, carefully plan for
+   required IP ranges and future scenarios.
+  </para>
+  <para>
+   Additionally, keep the network requirements in mind, as stated in
+   <xref linkend="sec.deploy.requirements.network" />.
+  </para>
+ </sect1>
+
+<sect1 xml:id="sec.admin.troubleshooting.rbac">
+  <title>RBAC/PSP</title>
+  <para>
+
   </para>
  </sect1>
 </chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -196,7 +196,7 @@
  </sect1>
 
  <sect1 xml:id="sec.admin.troubleshooting.network_planning">
-  <title>Network Planing and Reconfiguration</title>
+  <title>Network Planning and Reconfiguration</title>
   <para>
    It is not possible to reconfigure the used IP ranges of &productname;
    once the deployment is complete. Therefore, carefully plan for

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -16,7 +16,7 @@
   </dm:docmanager>
   <abstract>
    <para>
-    This chapter summarizes frequent problems that occur while using
+    This chapter summarizes frequent problems that can occur while using
     &productname; and their solutions.
    </para>
   </abstract>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE chapter
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+<chapter version="5.1" xml:id="cha.admin.troubleshooting"
+  xmlns="http://docbook.org/ns/docbook"
+  xmlns:xi="http://www.w3.org/2001/XInclude"
+  xmlns:xlink="http://www.w3.org/1999/xlink">
+ <info>
+  <title>Troubleshooting</title>
+  <dm:docmanager xmlns:dm="urn:x-suse:ns:docmanager">
+   <dm:bugtracker/>
+   <dm:translation>yes</dm:translation>
+  </dm:docmanager>
+  <abstract>
+   <para>
+    This chapter summarizes frequent problems that occur while using
+    &productname; and their solutions.
+   </para>
+  </abstract>
+ </info>
+
+ <sect1 xml:id="sec.admin.troubleshooting.overview">
+  <title>Overview</title>
+  <para>
+   This chapter is a collection of frequent problems that are reported
+   for &productname;. Additionally, &suse; support collects problems
+   and their solutions online at <link
+   xlink:href="https://www.suse.com/support/kb/?id=SUSE_CaaS_Platform"
+   />.
+  </para>
+ </sect1>
+</chapter>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -75,8 +75,8 @@
    <step>
     <para>
      Check logs from Salt orchestration. If &productname; cluster
-     bootstrap fails in Velum, retry and look into
-     <command>salt-master</command> orchestration logs by executing:
+     bootstrap fails in Velum, look into <command>salt-master</command>
+     orchestration logs by executing:
     </para>
 <screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep "salt-master" | awk '{print $1}') \
     salt-run state.event pretty=True > salt-event.logs</command></screen>
@@ -200,13 +200,6 @@
   <para>
    Additionally, keep the network requirements in mind, as stated in
    <xref linkend="sec.deploy.requirements.network" />.
-  </para>
- </sect1>
-
- <sect1 xml:id="sec.admin.troubleshooting.rbac">
-  <title>RBAC/PSP</title>
-  <para>
-
   </para>
  </sect1>
 

--- a/xml/book_admin.xml
+++ b/xml/book_admin.xml
@@ -36,6 +36,7 @@
  <xi:include href="admin_logging.xml"/>
  <xi:include href="admin_misc.xml"/>
  <xi:include href="admin_integration_ses.xml"/>
+ <xi:include href="admin_troubleshooting.xml"/>
 <!-- ===================================================================== -->
 <!-- Appendix                                                              -->
 <!-- ===================================================================== -->

--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -787,6 +787,22 @@ runcmd:
    If you want to register your node at a &rmt; server, refer to the
    <emphasis>RMT Guide</emphasis> at <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/book_rmt.html"/>.
   </para>
+  <note xml:id="sec.configuration.suseconnect.proxy">
+   <title>Using a Proxy Server with Authentication</title>
+   <para>
+    Create the file <filename>/root/.curlrc</filename> with the content:
+   </para>
+<screen>--proxy https://<replaceable>PROXY_FQDN</replaceable>:<replaceable>PROXY_PORT</replaceable>
+--proxy-user "<replaceable>USER</replaceable>:<replaceable>PASSWORD</replaceable>"</screen>
+   <para>
+    Replace <replaceable>PROXY_FQDN</replaceable> with the fully
+    qualified domain name of the proxy server and
+    <replaceable>PROXY_PORT</replaceable> with its port. Replace
+    <replaceable>USER</replaceable> and
+    <replaceable>PASSWORD</replaceable> with the credentials of an
+    allowed user for the proxy server.
+   </para>
+  </note>
  </sect1>
 
 </chapter>

--- a/xml/deployment_installing_nodes.xml
+++ b/xml/deployment_installing_nodes.xml
@@ -126,9 +126,12 @@
         <literal>https</literal> or <literal>http</literal>; other
         protocols are not supported. Fill this field to enable
         installing current updates during the installation process.
-        Alternatively, the machine can be registered at the &scc; or
-        a &smt; server at any later point in time with
-        <command>SUSEConnect</command>.
+        Alternatively, the machine can be registered at the &scc; or a
+        &smt; server at any later point in time with
+        <command>SUSEConnect</command>. For details about registering
+        with <command>SUSEConnect</command> and using an authenticated
+        proxy server for registration, see <xref
+        linkend="sec.configuration.suseconnect" />.
        </para>
       </listitem>
      </varlistentry>

--- a/xml/deployment_installing_nodes.xml
+++ b/xml/deployment_installing_nodes.xml
@@ -1034,6 +1034,10 @@
 <!-- cwickert 2017-07-23: FIXME We are already past AutoYaST -->
 <!-- This process leverages &ay; and is (almost) fully automated. -->
   </para>
+  <para>
+   In case of problems, refer to <xref
+   linkend="sec.admin.troubleshooting.failed_bootstrap" />.
+  </para>
   <procedure xml:id="pro.deploy.install.bootstrap">
    <step>
     <para>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -269,7 +269,8 @@
 
 <!ENTITY prompt.root     "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>root # </prompt>">
 <!ENTITY prompt.root.admin "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>root@admin # </prompt>">
-<!ENTITY prompt.root.master "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>root@master # </prompt>"><!ENTITY prompt.user     "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserid; &gt; </prompt>">
+<!ENTITY prompt.root.master "<prompt role='root' xmlns='http://docbook.org/ns/docbook'>root@master # </prompt>">
+<!ENTITY prompt.user     "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserid; &gt; </prompt>">
 <!ENTITY prompt.user2    "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuser2id; &gt; </prompt>">
 <!ENTITY prompt.sudo     "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserid; &gt; sudo </prompt>">
 <!ENTITY prompt.bash     "<prompt xmlns='http://docbook.org/ns/docbook'>bash-4.3 # </prompt>">


### PR DESCRIPTION
Add a Troubleshooting chapter to the Admin Guide. Some sections are added to other chapters and linked to the general Troubleshooting chapter.

Review here:
* https://w3.nue.suse.com/~sseebergelverfeldt/book.caasp.deployment/
* https://w3.nue.suse.com/~sseebergelverfeldt/book.caasp.admin/#cha.admin.troubleshooting