### PR TITLE
fix cloud-init kernel parameter

### DIFF
--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -179,7 +179,7 @@
     <filename>cloud.cfg</filename>, but you have to configure network first,
     for example by using local configuration files. The url is specified as a boot
     parameter and must be in the format:
-    <literal>cloud-init-url=http://<replaceable>hostname.domain</replaceable>/cloud.cfg</literal>.
+    <literal>cloud-config-url=http://<replaceable>hostname.domain</replaceable>/cloud.cfg</literal>.
     The content of the passed url is copied to
     <filename>/etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg</filename> and
     it is not overwritten even though the url changes. For details about


### PR DESCRIPTION
According to [cloud-init documentation](
https://git.launchpad.net/cloud-init/tree/doc/sources/kernel-cmdline.txt) the kernel parameter is called `cloud-config-url` or `url` instead of `cloud-init-url`. 

If `cloud-init-url` is used, the file `/etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg` is not created.
