### PR TITLE
Change 'Configuring Remote Container Registry'

### DIFF
--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -929,8 +929,8 @@ worker-4   Ready,SchedulingDisabled   &lt;none>    21h       v1.9.8
    create trust between Kubernetes and the registry.
   </para>
   <para>
-   By default, the &suse; container registry is configured as the only remote
-   registry and has the name <literal>SUSE</literal>.
+   By default, Docker Hub and the &suse; container registry are
+   available sources for container images.
   </para>
 
   <informalfigure>


### PR DESCRIPTION
* Docker Hub is available by default.