### PR TITLE
deployment: sysreqs: Fix typo when describing worker threads

### DIFF
--- a/xml/deployment_sysreqs.xml
+++ b/xml/deployment_sysreqs.xml
@@ -52,8 +52,8 @@
    <title>Salt Cluster Sizing</title>
    <para>
     &productname; relies on SaltStack (or Salt for short) to automate various
-    tasks. The actions are performed by so called "minions". A minion can handle
-    a theoretical number of nodes at the same time. Salt assigns a configured
+    tasks. The actions are performed by so called "minions". A master can handle
+    a theoretical number of minions at the same time. Salt assigns a configured
     number of "worker threads" to the minions. The number of available
     worker threads limits the overall size of the cluster.
     </para>


### PR DESCRIPTION
The worker threads are being assigned on the master node instead of
the minions. This also renames 'nodes' with 'minions' to be consistent
with the rest of the paragraph.