### PR TITLE
Update links to upstream k8s docs

### DIFF
--- a/xml/admin_logging.xml
+++ b/xml/admin_logging.xml
@@ -449,7 +449,7 @@ cmd.run "journalctl -u transactional-update"</command>
    <title>Kubernetes Audit Log Documentation</title>
    <para>
     For more information on the audit log and its contents, see:
-    <link xlink:href="https://v1-9.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/">Kubernetes
+    <link xlink:href="https://v1-10.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/">Kubernetes
     Documentation: Auditing</link>
    </para>
   </note>
@@ -517,7 +517,7 @@ cmd.run "journalctl -u transactional-update"</command>
     <listitem>
      <para>
       The YAML file defining the
-      <link xlink:href="https://v1-9.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy">auditing
+      <link xlink:href="https://v1-10.docs.kubernetes.io/docs/tasks/debug-application-cluster/audit/#audit-policy">auditing
       policy rules</link>
      </para>
     </listitem>

--- a/xml/admin_security.xml
+++ b/xml/admin_security.xml
@@ -67,7 +67,7 @@
      <para>
       Admission controllers in &kube; can mutate and validate requests.
       For details, refer to <link xlink:href=
-      "https://v1-9.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/"
+      "https://v1-10.docs.kubernetes.io/docs/reference/access-authn-authz/admission-controllers/"
       />.
      </para>
     </listitem>
@@ -76,7 +76,7 @@
   <para>
    For details about access control in &kube;, refer to <link
    xlink:href=
-   "https://v1-9.docs.kubernetes.io/docs/reference/access-authn-authz/controlling-access/"
+   "https://v1-10.docs.kubernetes.io/docs/reference/access-authn-authz/controlling-access/"
    />.
   </para>
  </sect1>
@@ -590,7 +590,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/"
+       "https://v1-10.docs.kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/"
        />
       </para>
      </listitem>
@@ -600,7 +600,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/"
+       "https://v1-10.docs.kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/"
        />
       </para>
      </listitem>
@@ -610,7 +610,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/"
        />
       </para>
      </listitem>
@@ -620,7 +620,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/controllers/daemonset/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/controllers/daemonset/"
        />
       </para>
      </listitem>
@@ -630,7 +630,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/controllers/deployment/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/controllers/deployment/"
        />
       </para>
      </listitem>
@@ -640,7 +640,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/services-networking/ingress/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/services-networking/ingress/"
        />
       </para>
      </listitem>
@@ -650,7 +650,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/"
        />
       </para>
      </listitem>
@@ -660,7 +660,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/"
        />
       </para>
      </listitem>
@@ -670,7 +670,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/architecture/nodes/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/architecture/nodes/"
        />
       </para>
      </listitem>
@@ -680,7 +680,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/pods/pod-overview/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/pods/pod-overview/"
        />
       </para>
      </listitem>
@@ -690,7 +690,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/storage/persistent-volumes/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/storage/persistent-volumes/"
        />
       </para>
      </listitem>
@@ -700,7 +700,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/configuration/secret/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/configuration/secret/"
        />
       </para>
      </listitem>
@@ -710,7 +710,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/services-networking/service/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/services-networking/service/"
        />
       </para>
      </listitem>
@@ -720,7 +720,7 @@ uniqueMember: uid=<replaceable>member3</replaceable>,<xref linkend="co.admin.sec
      <listitem>
       <para>
        <link xlink:href=
-       "https://v1-9.docs.kubernetes.io/docs/concepts/workloads/controllers/replicaset/"
+       "https://v1-10.docs.kubernetes.io/docs/concepts/workloads/controllers/replicaset/"
        />
       </para>
      </listitem>
@@ -1035,7 +1035,7 @@ roleRef:
   </para>
   <para>
    Detailed information is available at <link xlink:href=
-  "https://v1-9.docs.kubernetes.io/docs/concepts/policy/pod-security-policy/"
+  "https://v1-10.docs.kubernetes.io/docs/concepts/policy/pod-security-policy/"
   />.
   </para>
   <example xml:id="ex.admin.security.pod_policies.unprivileged">


### PR DESCRIPTION
CaaSP maintenance update will update k8s to 1.10.11 to migitgate CVE-2018-1002105
Update links to correct upstream docs version