### PR TITLE
Fix docker command for obtaining container name

### DIFF
--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -894,7 +894,7 @@ worker-4   Ready,SchedulingDisabled   &lt;none>    21h       v1.9.8
    following on the &admin_node;:
   </para>
 <screen>&prompt.root;<command>echo "worker_threads: 20" > /etc/caasp/salt-master-custom.conf</command>
-&prompt.root;<command>docker restart $(docker ps | grep salt-master | awk '{print $1}')</command></screen>
+&prompt.root;<command>docker restart $(docker ps -q -f name="salt-master")</command></screen>
   <para>
    &smaster; will be automatically restarted by kubelet.
   </para>
@@ -902,8 +902,8 @@ worker-4   Ready,SchedulingDisabled   &lt;none>    21h       v1.9.8
    Following bootstrapping failure, you can check if Salt
    worker_threads is too low.
   </para>
-<screen>&prompt.root;<command>docker logs $(docker ps | grep salt-master | \
-    awk '{print $1}') 2>&amp;1 | grep -i worker_threads</command></screen>
+<screen>&prompt.root;<command>docker logs $(docker ps -q -f name="salt-master") \
+    | grep -i worker_threads</command></screen>
  </sect1>
 
  <sect1 xml:id="sec.admin.velum.registry">

--- a/xml/admin_security.xml
+++ b/xml/admin_security.xml
@@ -241,8 +241,8 @@ $UNAME -s <replaceable>new_password</replaceable></command>
      Import the LDAP certificate to your local trusted certificate
      storage. On the &admin_node;, run:
     </para>
-<screen>&prompt.root.admin;<command>docker exec -it $(docker ps | grep openldap | \
-awk '{print $1}') cat /etc/openldap/pki/ca.crt > ~/ca.pem</command>
+<screen>&prompt.root.admin;<command>docker exec -it $(docker ps -q -f name=ldap) \
+cat /etc/openldap/pki/ca.crt > ~/ca.pem</command>
 &prompt.root.admin;<command>scp ~/ca.pem root@<replaceable>WORKSTATION</replaceable>:/usr/share/pki/trust/anchors/ca-caasp.crt.pem</command></screen>
     <para>
      Replace <replaceable>WORKSTATION</replaceable> with the appropriate

--- a/xml/admin_software.xml
+++ b/xml/admin_software.xml
@@ -415,7 +415,7 @@ salt '*' system.reboot</command></screen>
       Start the update with debug output.
      </para>
 <screen>&prompt.root.admin;<command>docker exec -it $(docker ps -q -f name="salt-master") \
-    awk '{print $1}') salt-run -l debug state.orchestrate orch.update</command></screen>
+    salt-run -l debug state.orchestrate orch.update</command></screen>
     </step>
     <step>
      <para>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -70,7 +70,7 @@
     <para>
      Check the logs from Velum dashboard. Execute on the &admin_node;:
     </para>
-    <screen>&prompt.root.admin;<command>docker logs $(docker ps | grep "velum-dashboard" | awk '{print $1}')</command></screen>
+    <screen>&prompt.root.admin;<command>docker logs $(docker ps -q -f name="velum-dashboard")</command></screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
Here is a couple of fixes related to obtaining the container name

The first one fixes a typo and the second one makes the docs consistent by using the same method to obtain the container name across all sections.