### PR TITLE
fixed the OpenLDAP example

### DIFF
--- a/xml/admin_logging.xml
+++ b/xml/admin_logging.xml
@@ -172,7 +172,7 @@
     <filename>k8s_openldap_velum</filename> container running on the admin
     node.
    </para>
-<screen>&prompt.user;<command>docker logs $(docker ps -q -f name="k8s_velum-dashboard")</command>
+<screen>&prompt.user;<command>docker logs $(docker ps -q -f name="k8s_openldap_velum")</command>
     </screen>
   </sect2>
  </sect1>


### PR DESCRIPTION
The OpenLDAP log example was referring to the k8s_velum-dashboard container and not the k8s_openldap_velum container