### PR TITLE
deployment: Add instructions for Cilium deployment

### DIFF
--- a/xml/deployment_appendix.xml
+++ b/xml/deployment_appendix.xml
@@ -14,7 +14,7 @@
       </dm:docmanager>
     </info>
     <para/>
- <sect1 xml:id="deployment.appendix">
+ <sect1 xml:id="deployment.appendix.admin_node">
   <title>Installing an &Admin_Node; using &ay;</title>
   
   <para/>
@@ -55,5 +55,132 @@
    For more information about using pre-hashed passwords, refer to 
    <xref linkend="sec.deploy.cloud-init.user-data.password"/>.
   </para>
+ </sect1>
+ <sect1 xml:id="deployment.appendix.cilium">
+  <title>Installing &cilium;</title>
+
+  <para />
+
+  <para>
+   &cilium; is a &cni; plugin and daemon which uses &ebpf; in-kernel virtual
+   machine for implementing &net_pols;. It's introduced in &productname; v4 as
+   a tech preview feature.
+  </para>
+  <para>
+   &flannel;, which is a default CNI plugin in &productname; does not support
+   &net_pols;.
+  </para>
+  <sect2 xml:id="deployment.appendix.cilium.disclaimers">
+   <title>Disclaimers</title>
+   <para>
+    This document describes temporary way of &cilium; deployment. Before
+    releasing &productname; v4, &cilium; deployment will be supported by
+    &dashboard;.
+   </para>
+   <para>
+    All steps need to be done <emphasis role="strong">before</emphasis> the
+    cluster is deployed with &dashboard;.
+   </para>
+   <para>
+    The current implementation of &cilium; deployment in &productname; does not
+    allow yet to use L7 network policies (only L3 and L4). The support of L7
+    policies will be enabled when &envoy; will be packaged and shipped in
+    &opensuse; and &sle;. &envoy; will also bring a possibility of creating a
+    &svc_mesh; with &istio;.
+   </para>
+   <para>
+    For now &opensuse; and &sle; provide &cilium; in version 1.2, but it is
+    going to be upgraded to version 1.4.
+   </para>
+  </sect2>
+  <sect2 xml:id="deployment.appendix.cilium.image">
+   <title>Pre-loading of the &cilium; container image</title>
+   <para>
+    If all your cluster nodes have access to the Internet / external network,
+    please skip this section.
+   </para>
+   <para>
+    &cilium; container image is stored in the &opensuse; registry. The full
+    name of the image is <literal>&cilium_image;</literal>. If your cluster
+    nodes do not have access to the external network, the image needs to be
+    downloaded and copied to each node.
+   </para>
+   <procedure>
+    <title>Pre-loading of the &cilium; container image</title>
+    <step>
+     <para>
+      On a machine running docker, connected to the internet, perform:
+<screen>&prompt.root;<command>docker pull &cilium_image;</command>
+&prompt.root;<command>docker save &cilium_image; -o cilium.tar</command></screen>
+     </para>
+     <para>
+      This will save the image in <filename>cilium.tar</filename> file.
+     </para>
+    </step>
+    <step>
+     <para>
+      Copy <filename>cilium.tar</filename> to each node of the cluster.
+     </para>
+    </step>
+    <step>
+     <para>
+      On each node of the cluster perform the following command:
+<screen>&prompt.root;<command>docker load -i cilium.tar</command></screen>
+     </para>
+    </step>
+   </procedure>
+  </sect2>
+  <sect2 xml:id="deployment.appendix.cilium.salt-conf">
+   <title>Configuring of &smaster; to deploy &cilium;</title>
+   <procedure>
+    <title>Change &smaster; configuration to choose &cilium; as a &cni; plugin</title>
+    <step>
+     <para>
+      Connect to the &Admin_Node; and execute the following command:
+     </para>
+     <screen>&prompt.root;<command>transactional update shell</command></screen>
+     <para>
+      You will find yourself into a new shell prompt.
+     </para>
+    </step>
+    <step>
+     <para>
+      From this shell edit the
+      <filename>/usr/share/salt/kubernetes/pillar/cni.sls</filename> file.
+      Remove the whole <literal>flannel</literal> section. Inside
+      <literal>cni</literal> section, change the <literal>plugin</literal> from
+      <literal>flannel</literal> to <literal>cilium</literal>.
+     </para>
+     <para>
+      The file should look like that:
+<screen>cilium:
+  image:  'registry.opensuse.org/devel/caasp/kubic-container/container/kubic/cilium:1.2'
+
+cni:
+  plugin: 'cilium'
+  dirs:
+    bin:  '/var/lib/kubelet/cni/bin'
+    conf: '/etc/cni/net.d'</screen>
+     </para>
+    </step>
+    <step>
+     <para>
+      Once the file contents are changed, exit from the shell and reboot the
+      system:
+<screen>&prompt.root;<command>exit</command>
+&prompt.root;<command>reboot</command></screen>
+     </para>
+    </step>
+   </procedure>
+  </sect2>
+  <sect2 xml:id="deployment.appendix.cilium.deploying">
+   <title>Deploying the cluster</title>
+   <para>
+    After the successful reboot, go to &dashboard; web interface and
+    proceed with the deployment of the cluster. Feel free to change the
+    networking settings on the bootstrap page (i.e. <literal>CIDR</literal>);
+    all these settings are going to be used by &cilium;.
+   </para>
+  </sect2>
  </sect1>
 </appendix>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -117,6 +117,8 @@
 <!ENTITY ovs            "<phrase role='productname' xmlns='http://docbook.org/ns/docbook'>Open vSwitch</phrase>">
 <!ENTITY netteam       "Network Teaming">
 
+<!ENTITY ebpf           "eBPF">
+
 <!-- daemons -->
 <!ENTITY systemd       "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>systemd</systemitem>">
 <!ENTITY crond         "<systemitem xmlns='http://docbook.org/ns/docbook' class='daemon'>cron</systemitem>">
@@ -152,6 +154,11 @@
 <!ENTITY helm          "Helm">
 <!ENTITY tiller        "Tiller">
 <!ENTITY ostack        "OpenStack">
+<!ENTITY cilium        "Cilium">
+<!ENTITY cni           "CNI">
+<!ENTITY envoy         "Envoy">
+<!ENTITY flannel       "Flannel">
+<!ENTITY istio         "Istio">
 
 
 <!-- ============================================================= -->
@@ -262,6 +269,9 @@
 <!ENTITY tupdate       "<command xmlns='http://docbook.org/ns/docbook'>transactional-update</command>">
 <!ENTITY caasp-cli     "<command xmlns='http://docbook.org/ns/docbook'>caasp-cli</command>">
 <!ENTITY kubedoc       "https://v1-11.docs.kubernetes.io/docs/">
+<!ENTITY net_pol       "Network Policy">
+<!ENTITY net_pols      "Network Policies">
+<!ENTITY svc_mesh      "Service Mesh">
 
 <!-- ============================================================= -->
 <!-- Prompts                                                       -->
@@ -275,6 +285,11 @@
 <!ENTITY prompt.sudo     "<prompt xmlns='http://docbook.org/ns/docbook'>&exampleuserid; &gt; sudo </prompt>">
 <!ENTITY prompt.bash     "<prompt xmlns='http://docbook.org/ns/docbook'>bash-4.3 # </prompt>">
 
+<!-- ============================================================= -->
+<!-- Container images                                              -->
+<!-- ============================================================= -->
+
+<!ENTITY cilium_image  "registry.opensuse.org/devel/caasp/kubic-container/container/kubic/cilium:1.2">
 
 <!-- ============================================================= -->
 <!-- Do not change                                                 -->


### PR DESCRIPTION
Add instructions for Cilium deployment with currently available salt
formulas and image from the openSUSE registry.

Please note that those instructions are temporary. When
kubic-project/velum#701 is merged, Cilium deployment will be
available in Velum dashboard without any manual changes.