### PR TITLE
cilium: Fix typo in the t-u shell command

### DIFF
--- a/xml/deployment_appendix.xml
+++ b/xml/deployment_appendix.xml
@@ -139,7 +139,7 @@
      <para>
       Connect to the &Admin_Node; and execute the following command:
      </para>
-     <screen>&prompt.root;<command>transactional update shell</command></screen>
+     <screen>&prompt.root;<command>transactional-update shell</command></screen>
      <para>
       You will find yourself into a new shell prompt.
      </para>


### PR DESCRIPTION
`transactional update shell` -> `transactional-update shell`