### PR TITLE
Fix duplicate SUSE at start of Install Quick Start

### DIFF
--- a/xml/quick_intro.xml
+++ b/xml/quick_intro.xml
@@ -17,7 +17,7 @@
   </dm:docmanager>
  </info>
  <para>
- &suse; &productname; is a Cloud-Native Computing Foundation (CNCF) certified
+ &productname; is a Cloud-Native Computing Foundation (CNCF) certified
  &kube; distribution on top of &suse; &mos;.
  &suse; &mos; is a minimalist operating system based on &sle; 12 SP3, dedicated
  to hosting containers. &suse; &mos; OS inherits the benefits of &sle; in the


### PR DESCRIPTION
&productname includes SUSE so no need to include &suse