### PR TITLE
Link to specific release notes in Install Quick Start

### DIFF
--- a/xml/quick_intro.xml
+++ b/xml/quick_intro.xml
@@ -149,7 +149,7 @@
 
 <para>
  For more information, including a list of the various components which make up
- &productname; please refer to the Release Notes on <link
-  xlink:href="https://www.suse.com/releasenotes/"/>.
+ &productname; please refer to the Release Notes at <link
+  xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-CAASP/3.0/"/>.
 </para>
 </preface>


### PR DESCRIPTION
More helpful to link to version specific release notes in Installation Quick Start rather than dump someone at Release Notes for all SUSE products!