### PR TITLE
Link to specific release notes in System Requirements

### DIFF
--- a/xml/quick_system_requirements.xml
+++ b/xml/quick_system_requirements.xml
@@ -46,7 +46,7 @@
   </para>
   <para>Any number of &worker_node;s may be added up to the maximum cluster
    size. For the current maximum supported number of nodes, please refer to
-   the Release Notes on <link xlink:href="https://www.suse.com/releasenotes/"/>.
+   the Release Notes on <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-CAASP/3.0/"/>.
   </para>
  </sect1>
 

--- a/xml/quick_system_requirements.xml
+++ b/xml/quick_system_requirements.xml
@@ -46,7 +46,7 @@
   </para>
   <para>Any number of &worker_node;s may be added up to the maximum cluster
    size. For the current maximum supported number of nodes, please refer to
-   the Release Notes on <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-CAASP/3.0/"/>.
+   the Release Notes at <link xlink:href="https://www.suse.com/releasenotes/x86_64/SUSE-CAASP/3.0/"/>.
   </para>
  </sect1>
 


### PR DESCRIPTION
More helpful to link to version specific release notes in Installation Quick Start rather than dump someone at Release Notes for all SUSE products!