### PR TITLE
Link to specific Deployment Guide in Quick Start

### DIFF
--- a/xml/quick_install.xml
+++ b/xml/quick_install.xml
@@ -37,8 +37,8 @@
  </para>
  <para>
   For these and other deployment scenarios, see the &productname; Deployment
-  Guide on <link
-   xlink:href="http://www.suse.com/documentation/"/>.
+  Guide at <link
+   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/>.
  </para>
 
  <sect1 xml:id="sec.quick.install.admin">


### PR DESCRIPTION
More helpful to link to version specific Deployment Guide in Installation Quick Start rather than dump someone at Documentation page for all SUSE products!