### PR TITLE
Add Nutanix Acropolis to the Supported Environments chapter

### DIFF
--- a/xml/deployment_sysreqs.xml
+++ b/xml/deployment_sysreqs.xml
@@ -449,6 +449,11 @@
        Oracle VM 3.3
       </para>
      </listitem>
+     <listitem>
+      <para>
+       Nutanix Acropolis
+      </para>
+     </listitem>
     </itemizedlist>
    </listitem>
    <listitem>


### PR DESCRIPTION
Currently the CaaSP "Supported Environments" section does not cover Nutanix Acropolis as a virtualization infrastructure. Acropolis itself is either using its own KVM-based hypervisor AHV or another vendor like VMWare (which are already listed as supported). From a technical point of view it should not make much difference running CaaSP workloads on there as any other virtualization layer.

Can you please check back internally and get the green light to list Nutanix as an officially supported environment as well? I had some discussions with Andreas Jäger about that, he should know the details in case of doubts. ;)