### PR TITLE
Set the num of vCPU for the master a hard requirement

### DIFF
--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -26,6 +26,12 @@ Production environments must be deployed with multiple master nodes for resilien
 * RAM: 2 GB
 * Network: Minimum 1GB/s, faster preferred
 
+[IMPORTANT]
+====
+Using a minimum of 2 (v)CPU is a hard requirement, deploying
+a cluster with less is not possible.
+====
+
 ==== Worker
 
 * Storage: Depending on workloads, minimum 20-30GB to hold base OS and required packages


### PR DESCRIPTION
`kubeadm` will prevent the deployment of a cluster with less than 2 CPU. this is to ensure a minimum of 2 is not just a nice to have.

Signed-off-by: lcavajani <lcavajani@suse.com>