### PR TITLE
deployment_scenarios.xml: threshold unaligned

### DIFF
--- a/xml/deployment_scenarios.xml
+++ b/xml/deployment_scenarios.xml
@@ -937,7 +937,7 @@ health:
   storagedriver:
     enabled: true
     interval: 10s
-threshold: 3
+    threshold: 3
 </screen>
       <para>
        For more details on the configuration, refer to:


### PR DESCRIPTION
According with docker documentation, the field `threshold: 3`
should be under storagedriver. Close #283

https://docs.docker.com/registry/configuration/#health

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>