### PR TITLE
deployment_scenarios.xml: adds rmt ssl folder volume

### DIFF
--- a/xml/deployment_scenarios.xml
+++ b/xml/deployment_scenarios.xml
@@ -951,6 +951,7 @@ threshold: 3
       </para>
 <screen>&prompt.root;<command>docker run -d -p 5000:5000 --restart=always --name registry \
 -v /etc/docker/registry:/etc/docker/registry:ro \
+-v /etc/rmt/ssl:/etc/rmt/ssl:ro \
 -v <replaceable>/var/lib/registry</replaceable>:/var/lib/registry registry.suse.com/sles12/registry:2.6.2</command>
        </screen>
      </step>


### PR DESCRIPTION
The registry conf.yml file points to certificate under `/etc/rmt/ssl`
folder. However, the command to run the registry does not create a
volume to that directory in the registry container. Thus, the container
does not have access to the certificate. This commit adds that volume to
allow the registry read the necessary file. Close #282

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>