### PR TITLE
Fix Terraform example for VMWare deployment

### DIFF
--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -253,13 +253,13 @@ Name it reasonably so you can later identify the template. The template will be 
 
 ==== Terraform
 
-. Find the {tf} template files for {soc} in `/usr/share/caasp/terraform/openstack`.
+. Find the {tf} template files for {soc} in `/usr/share/caasp/terraform/vmware`.
 Copy this folder to a location of your choice as the files need adjustment.
 +
 ----
 mkdir -p ~/caasp/deployment/
-cp -r /usr/share/caasp/terraform/openstack/ ~/caasp/deployment/
-cd ~/caasp/deployment/openstack/
+cp -r /usr/share/caasp/terraform/vmware/ ~/caasp/deployment/
+cd ~/caasp/deployment/vmware/
 ----
 . Once the files are copied, rename the `terraform.tfvars.example` file to
 `terraform.tfvars`:


### PR DESCRIPTION
The current documentation under the VMWare deployment is having
an example from OpenStack instead from VMWare. The detailed
description seems to be correct but the filenames are pointing
to the openstack infrastructure configuration. This PR is replacing
the paths with the vmware directory.