### PR TITLE
Skip self-signed certificate verification for VMWare

### DIFF
--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -305,6 +305,10 @@ terraform plan
 terraform apply
 ----
 
+.Skip self-signed certificate verification
+[TIP]
+In case you are using a self-signed certificate you need to skip its verification, as Terraform vsphere provider is not supporting it, thus `terraform plan` will fail. To do this, type the following in your terminal session: `export VSPHERE_ALLOW_UNVERIFIED_SSL=true`
+
 ==== Setup by hand
 
 . Right-click on the template and select menu:New VM from This Template...[] and name it something like `caasp4-master-0`.


### PR DESCRIPTION
SUSE is using _self-signed_ certificate (see ca-certificates-suse)
and this creates problems with Terraform and VSphere provider.

See: https://github.com/hashicorp/terraform/issues/10400

As a result, `terraform plan` is going to crash with the following error:

```
Error: Error refreshing state: 1 error occurred:
	* provider.vsphere: error setting up new vSphere SOAP client: Post https://jazz.qa.prv.suse.net/sdk: x509: certificate signed by unknown authority
```


Most companies provide proper signed certs. However, in case one of our customers do not, then they need to know what the workaround is. I don't know if we need to put that into the docs or not, I have no strong opinion about it.