### PR TITLE
Fix installation media urls

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -5,8 +5,7 @@
 :caasp_repo_url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
 :isofile: SLE-15-SP1-Installer-DVD-x86_64-Build225.1-Media1.iso
 :isolink: http://download.suse.de/install/SLE-15-SP1-Installer-GMC1/
-// FIXME this link needs to be checked once the beta page is online
-:download_url: https://www.suse.com/betaprogram/sle-beta/#download
+:jeos_product_page_url: https://www.suse.com/products/server/jeos/
 
 // Product Versions
 

--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -4,7 +4,6 @@
 // Media Locations
 :caasp_repo_url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
 :isofile: SLE-15-SP1-Installer-DVD-x86_64-Build225.1-Media1.iso
-:isolink: http://download.suse.de/install/SLE-15-SP1-Installer-GMC1/
 :jeos_product_page_url: https://www.suse.com/products/server/jeos/
 
 // Product Versions

--- a/adoc/deployment-ecp.adoc
+++ b/adoc/deployment-ecp.adoc
@@ -19,7 +19,7 @@ source container-openrc.sh
 ----
 .. Enter the password for the RC file. This should be same credentials that you use to log in to {soc}.
 . Get the SLES15-SP1 image.
-.. Download the latest SUSE SLES15-SP1 for {soc} from {download_url}.
+.. Download the pre-built image of SUSE SLES15-SP1 for {soc} from {jeos_product_page_url}.
 .. Upload the image to your {soc}.
 
 === Deploying the cluster nodes

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -40,7 +40,7 @@ ssh root@vmware.esxi.node
 ----
 cd /vmfs/volumes/my-directory/
 ----
-. Download the installation media from {download_url}
+. Download the pre-built image of SUSE SLES15-SP1 for VMWare from {jeos_product_page_url}
 
 Now you can create a new base VM for {productname} within the designated resource
 pool through the vSphere WebUI:


### PR DESCRIPTION
Fixed the deployment docs of OpenStack and VMware to use the right download URL.

Removed a no longer used variable.

The commit messages hold all the missing details.