### PR TITLE
Fix RFC5424 message example

### DIFF
--- a/adoc/admin-centralized-logging.adoc
+++ b/adoc/admin-centralized-logging.adoc
@@ -51,7 +51,7 @@ Example RFC 3164
 
 Example RFC 5424
 ----
-<133>1 2019-05-30T08:28:38.784214+00:00 master0 k8s.pod/kube-system/kube-apiserver-master0/kube-apiserver - - [kube_meta namespace_id=1e030def-81db-11e9-a62b-fa163e1876c9 container_name=kube-apiserver creation_timestamp=2019-05-29T06:29:31Z host=master0 namespace_name=kube-system master_url=https://kubernetes.default.svc.cluster.local:443 pod_id=4aaf10f9-81db-11e9-a62b-fa163e1876c9 pod_name=kube-apiserver-master0] 2019-05-30T08:28:38.783780355+00:00 stderr F I0530 08:28:38.783710       1 log.go:172] http: TLS handshake error from 172.28.0.19:45888: tls: client offered only unsupported versions: [300]
+<133>1 2019-05-30T08:28:38.784214+00:00 master0 k8s.pod/kube-system/kube-apiserver-master0/kube-apiserver - - [kube_meta namespace_id="1e030def-81db-11e9-a62b-fa163e1876c9" container_name="kube-apiserver" creation_timestamp="2019-05-29T06:29:31Z" host="master0" namespace_name="kube-system" master_url="https://kubernetes.default.svc.cluster.local:443" pod_id="4aaf10f9-81db-11e9-a62b-fa163e1876c9" pod_name="kube-apiserver-master0"] 2019-05-30T08:28:38.783780355+00:00 stderr F I0530 08:28:38.783710       1 log.go:172] http: TLS handshake error from 172.28.0.19:45888: tls: client offered only unsupported versions: [300]
 ----
 
 


### PR DESCRIPTION
Add missing double quotes to enclose keys and values of structured data for qualified RFC5424 message format.