### PR TITLE
fix quickstart title

### DIFF
--- a/xml/book_quick_start.xml
+++ b/xml/book_quick_start.xml
@@ -12,7 +12,7 @@
   xmlns:xi="http://www.w3.org/2001/XInclude"
   xmlns:xlink="http://www.w3.org/1999/xlink">
  <info>
-  <title>&deploy;</title><productname>&productname;</productname>
+  <title>&instquick;</title><productname>&productname;</productname>
   <productnumber>&productnumber;</productnumber><date>
 <?dbtimestamp format="B d, Y"?></date>
   <xi:include href="common_copyright_gfdl.xml"/>


### PR DESCRIPTION
### Docserv² Navigation page was not showing the right title for quickstart guide. This should hopefully fix that.