### PR TITLE
Clarify sudo requirements on nodes

### DIFF
--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -26,7 +26,7 @@ use the `skuba node join` command to add more nodes.
 [source,bash]
 skuba node join --role <master/worker> --user <user-name> --sudo --target <IP/FQDN> <node-name>
 
-The mandatory flags for the join command are `--role`, ``--user`, `--sudo` and `--target`.
+The mandatory flags for the join command are `--role`, `--user`, `--sudo` and `--target`.
 
 - `--role` serves to specify if the node is a *master* or *worker*
 - `--sudo` is for running the command with superuser privileges,

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -51,12 +51,29 @@ This can be achieved using the `ssh -A` command. Please refer to the man page
 of ssh to learn about the security implications of using this feature.
 ====
 
+By default `skuba` connects to the nodes as `root` user. A different user can
+be specified by the following flags:
+
+----
+--sudo --user <username>
+----
+
+[IMPORTANT]
+====
+You must configure `sudo` for the user to be able authenticate without password.
+Replace `USERNAME` with the user you created during installation. As root, run:
+
+----
+echo "USERNAME ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+----
+====
+
 ==== Initializing the Cluster
 
-. Now you can initialize the cluster on the deployed machines.
+Now you can initialize the cluster on the deployed machines.
 As `--control-plane` enter the IP/FQDN of your load balancer.
 If you do not use a load balancer use your first master node.
-+
+
 ----
 skuba cluster init --control-plane <LB IP/FQDN> my-cluster
 ----


### PR DESCRIPTION
Users must be aware `sudo` must be configured to allow the user specified via `skuba` to work in password-less mode.

This is required to fix [bsc#1140635](https://bugzilla.suse.com/show_bug.cgi?id=1140635).

I also took the chance to fix some minor rendering issues inside of the docs.
