### PR TITLE
Add OpenStack cloud provider documentation

### DIFF
--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -70,6 +70,77 @@ The IP/FQDN must be reachable by every node of the cluster and therefore 127.0.0
 
 At this point you can perform some configurations before bootstrapping the cluster.
 
+===== Enable cloud provider integration
+
+Enable cloud provider integration to take advantage of the underlying cloud platforms 
+to automatically manage resources like Load Balancer, Nodes (Instances), Network Routes 
+and Storage services. +
+If you want to enable cloud provider integration with different cloud platforms, 
+you have to initialize the cluster with flag `--cloud-provider <CLOUD PROVIDER>`. +
+Currently it is available only for `openstack` but more possibility will be added.
+
+----
+skuba cluster init --control-plane <LB IP/FQDN> --cloud-provider openstack my-cluster
+----
+
+It will create the directory `my-cluster/cloud/openstack` with `README.md` and `openstack.conf.template` in it.
+You have to copy `openstack.conf.template` or create a `openstack.conf` file inside `my-cluster/cloud/openstack`, 
+with the [supported contents] (https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#openstack) +
+
+[WARNING]
+====
+It is required that `my-cluster/cloud/openstack/openstack.conf` file is not accessible by others. 
+Please remember to set proper file permissions for it, for example `600`.
+====
+
+====
+# Example OpenStack cloud provider configuration
+
+    [Global]
+    auth-url="https://keystone.example.com:5000/v3" // <1>
+    username="TestUser" // <2>
+    password="Secure.Password123#" // <3>
+    tenant-id="05394ae447d74bc0b3ed2cca262c9b7c" // <4>
+    domain-name="DomainUser" // <5>
+    region="CustomRegion" // <6>
+    ca-file="/etc/ssl/certs/SUSE_Trust_Root.pem" // <7>
+    [LoadBalancer]
+    lb-version=v2 // <8>
+    subnet-id="70041812-2387-41e4-a1cf-43ddddc83634" // <9>
+    floating-network-id="890584bc-da17-424b-9147-2dc8f3d69d64" // <10>
+    create-monitor=yes // <11>
+    monitor-delay=1m // <12>
+    monitor-timeout=30s // <13>
+    monitor-max-retries=3 // <14>
+    [BlockStorage]
+    bs-version=v2 // <15>
+    ignore-volume-az=true // <16>
+====
+<1> (required) Specifies the URL of the Keystone API used to authenticate the user. This value can be found in Horizon (the OpenStack control panel) under Project → Access and Security → API Access → Credentials.
+<2> (required) Refers to the username of a valid user set in Keystone.
+<3> (required) Refers to the password of a valid user set in Keystone.
+<4> (required) Used to specify the id of the project where you want to create your resources
+<5> (optional) Used to specify the name of the domain your user belongs to.
+<6> (optional) Used to specify the identifier of the region to use when running on a multi-region OpenStack cloud. A region is a general division of an OpenStack deployment.
+<7> (optional) Used to specify the path to your custom CA file
+<8> (optional) Used to override automatic version detection. Valid values are `v1` or `v2`. Where no value is provided automatic detection will select the highest supported version exposed by the underlying OpenStack cloud.
+<9> (optional) Used to specify the id of the subnet you want to create your loadbalancer on. Can be found at Network > Networks. Click on the respective network to get its subnets.
+<10> (optional) If specified, will create a floating IP for the load balancer.
+<11> (optional) Indicates whether or not to create a health monitor for the Neutron load balancer. Valid values are true and false. The default is false. When true is specified then monitor-delay, monitor-timeout, and monitor-max-retries must also be set.
+<12> (optional) The time between sending probes to members of the load balancer. Ensure that you specify a valid time unit.
+<13> (optional) Maximum time for a monitor to wait for a ping reply before it times out. The value must be less than the delay value. Ensure that you specify a valid time unit. 
+<14> (optional) Number of permissible ping failures before changing the load balancer member’s status to INACTIVE. Must be a number between 1 and 10.
+<15> (optional) Used to override automatic version detection. Valid values are v1, v2, v3 and auto. When auto is specified automatic detection will select the highest supported version exposed by the underlying OpenStack cloud.
+<16> (optional) Influence availability zone use when attaching Cinder volumes. When Nova and Cinder have different availability zones, this should be set to `true`.
++
+After setting options in `openstack.conf` file, please procceed with the bootstrapping procedure <<cluster.bootstrap>>.
+
+[IMPORTANT]
+====
+When the cloud provider integration is enabled, it's very important to bootstrap and join nodes with the same node names that they have inside `Openstack`, as
+this name will be used by the `Openstack` cloud controller manager to reconcile node metadata.
+====
+
 ===== Integrate External LDAP
 
 . Open the `Dex` `ConfigMap` in `my-cluster/addons/dex/dex.yaml`
@@ -182,6 +253,7 @@ kubectl apply -f my-cluster/addons/kured/kured.yaml
 
 This will restart all `kured` pods with the additional configuration flags.
 
+[[cluster.bootstrap]]
 ==== Cluster bootstrap
 . Switch to the new directory.
 . Now bootstrap a master node.


### PR DESCRIPTION
This is adding new section in deployment documentation
about OpenStack cloud provider integration.