### PR TITLE
use better network info for proxy

### DIFF
--- a/adoc/admin-crio-proxy.adoc
+++ b/adoc/admin-crio-proxy.adoc
@@ -16,7 +16,7 @@ root# systemctl restart crio
 === Configuration example
 
 ----
-NO_PROXY="localhost,127.0.0.1,3.0.0.0/8,192.168.0.0/16,10.0.0.0/8,.suse.com"
-HTTP_PROXY="http://3.28.26.214:88/"
-HTTPS_PROXY="http://3.28.26.214:88/"
+NO_PROXY="localhost,127.0.0.1,192.168.0.0/16,10.0.0.0/8,.example.com"
+HTTP_PROXY="http://192.168.22.22:3128"
+HTTPS_PROXY="http://192.168.22.22:3128"
 ----


### PR DESCRIPTION
I've updated the network addresses and domains to set something more realistic.

`.suse.com` is on Internet so not proxyfying would be a strange configuration
`3.0.0.0/8` is owned by Amazon so it's a bit weird again to not proxy stuff to Internet
`192.168.22.22:3128` looks more like a real proxy address (private IP + default squid port)

Signed-off-by: lcavajani <lcavajani@suse.com>