### PR TITLE
Fix layout of the network ports table

### DIFF
--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -110,7 +110,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |===
 |Node |Port |Accessibility |Description
 
-.2+|All nodes
+.3+|All nodes
 |22
 |Internal
 |SSH (required in public clouds)
@@ -123,7 +123,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Dex (OIDC Connect)
 
-.6+|Masters
+.7+|Masters
 |2379 - 2380
 |Internal
 |etcd (peer-to-peer traffic)
@@ -152,7 +152,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Gangway (RBAC Authenticate)
 
-.6+|Workers
+.7+|Workers
 |2379 - 2380
 |Internal
 |etcd (peer-to-peer traffic)


### PR DESCRIPTION
The layout of the table got completely messed up when new rows got added by the "row span" rules were not updated to reflect that.

As a result the cells of the table got scrambled, making the table hard to understand.