### PR TITLE
Fix network ports description

### DIFF
--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -110,7 +110,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |===
 |Node |Port |Protocol | Accessibility |Description
 
-.6+|All nodes
+.8+|All nodes
 |22
 |TCP
 |Internal
@@ -146,6 +146,11 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Dex (OIDC Connect)
 
+|32001
+|TCP
+|External
+|Gangway (RBAC Authenticate)
+
 .5+|Masters
 |2379
 |TCP
@@ -162,27 +167,6 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal / External
 |Kubernetes API server
 
-|32000
-|TCP
-|External
-|Dex (OIDC Connect)
-
-|32001
-|TCP
-|External
-|Gangway (RBAC Authenticate)
-
-.2+|Workers
-
-|32000
-|TCP
-|External
-|Dex (OIDC Connect)
-
-|32001
-|TCP
-|External
-|Gangway (RBAC Authenticate)
 |===
 
 ==== IP Addresses

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -147,7 +147,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal
 |VXLAN traffic (used by Cilium)
 
-|10250, 20255
+|10250
 |TCP
 |Internal
 |Kubelet

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -137,7 +137,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal
 |etcd (server-to-server traffic)
 
-|6443 - 6444
+|6443
 |TCP
 |Internal / External
 |Kubernetes API server

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -106,78 +106,95 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 
 ==== Ports
 
-[cols="2*.^,.^,.>"",options="header,autowidth"]
+[cols="3*.^,.^,.>"",options="header,autowidth"]
 |===
-|Node |Port |Accessibility |Description
+|Node |Port |Protocol | Accessibility |Description
 
 .3+|All nodes
 |22
+|TCP
 |Internal
 |SSH (required in public clouds)
 
 |10010
+|TCP
 |Internal
 |CRI-O stream port
 
 |32000
+|TCP
 |External
 |Dex (OIDC Connect)
 
 .7+|Masters
 |2379 - 2380
+|TCP
 |Internal
 |etcd (peer-to-peer traffic)
 
 |6443 - 6444
+|TCP
 |Internal / External
 |Kubernetes API server
 
 |8471 - 8472
+|UDP
 |Internal
 |VXLAN traffic (used by Cilium)
 
 |10250, 20255
+|TCP
 |Internal
 |Kubelet
 
 |10256
+|TCP
 |Internal
 |kube-proxy
 
 |32000
+|TCP
 |External
 |Dex (OIDC Connect)
 
 |32001
+|TCP
 |External
 |Gangway (RBAC Authenticate)
 
 .7+|Workers
 |2379 - 2380
+|TCP
 |Internal
 |etcd (peer-to-peer traffic)
 
 |4149
+|TCP
 |Internal
 |Kubelet
 
 |8471 - 8472
+|UDP
 |Internal
 |VXLAN traffic (used by Cilium)
 
 |10250
+|TCP
 |Internal
 |Kubelet
 
 |10256
+|TCP
 |Internal
 |kube-proxy
 
 |32000
+|TCP
 |External
 |Dex (OIDC Connect)
 
 |32001
+|TCP
 |External
 |Gangway (RBAC Authenticate)
 |===

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -116,15 +116,15 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal
 |SSH (required in public clouds)
 
-|8471 - 8472
+|4240
+|TCP + ICMP
+|Internal
+|Cilium health check
+
+|8472
 |UDP
 |Internal
-|VXLAN traffic (used by Cilium)
-
-|10010
-|TCP
-|Internal
-|CRI-O streaming port
+|Cilium VXLAN
 
 |10250
 |TCP

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -136,6 +136,11 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal
 |kube-proxy health check
 
+|30000 - 32767
+|TCP + UDP
+|Internal
+|Range of ports used by Kubernetes when allocating services of type `NodePort`
+
 |32000
 |TCP
 |External

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -167,12 +167,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Gangway (RBAC Authenticate)
 
-.6+|Workers
-|4149
-|TCP
-|Internal
-|Kubelet
-
+.5+|Workers
 |8471 - 8472
 |UDP
 |Internal

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -110,23 +110,38 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |===
 |Node |Port |Protocol | Accessibility |Description
 
-.3+|All nodes
+.6+|All nodes
 |22
 |TCP
 |Internal
 |SSH (required in public clouds)
 
+|8471 - 8472
+|UDP
+|Internal
+|VXLAN traffic (used by Cilium)
+
 |10010
 |TCP
 |Internal
-|CRI-O stream port
+|CRI-O streaming port
+
+|10250
+|TCP
+|Internal
+|Kubelet (API server -> kubelet communication)
+
+|10256
+|TCP
+|Internal
+|kube-proxy health check
 
 |32000
 |TCP
 |External
 |Dex (OIDC Connect)
 
-.8+|Masters
+.5+|Masters
 |2379
 |TCP
 |Internal
@@ -142,21 +157,6 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |Internal / External
 |Kubernetes API server
 
-|8471 - 8472
-|UDP
-|Internal
-|VXLAN traffic (used by Cilium)
-
-|10250
-|TCP
-|Internal
-|Kubelet
-
-|10256
-|TCP
-|Internal
-|kube-proxy
-
 |32000
 |TCP
 |External
@@ -167,21 +167,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Gangway (RBAC Authenticate)
 
-.5+|Workers
-|8471 - 8472
-|UDP
-|Internal
-|VXLAN traffic (used by Cilium)
-
-|10250
-|TCP
-|Internal
-|Kubelet
-
-|10256
-|TCP
-|Internal
-|kube-proxy
+.2+|Workers
 
 |32000
 |TCP

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -126,11 +126,16 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Dex (OIDC Connect)
 
-.7+|Masters
-|2379 - 2380
+.8+|Masters
+|2379
 |TCP
 |Internal
-|etcd (peer-to-peer traffic)
+|etcd (client communication)
+
+|2380
+|TCP
+|Internal
+|etcd (server-to-server traffic)
 
 |6443 - 6444
 |TCP
@@ -162,12 +167,7 @@ link:https://github.com/etcd-io/etcd/blob/master/Documentation/op-guide/hardware
 |External
 |Gangway (RBAC Authenticate)
 
-.7+|Workers
-|2379 - 2380
-|TCP
-|Internal
-|etcd (peer-to-peer traffic)
-
+.6+|Workers
 |4149
 |TCP
 |Internal


### PR DESCRIPTION
The current contents of the [network ports](https://susedoc.github.io/doc-caasp/master/caasp-quickstart/single-html/#_ports) table are wrong and "bad organized".

The following PR introduces these changes:

  * Ensure we document also the protocol being used by the application
  * Get rid of the requirements that are no longer relevant with v4
  * Remove duplication inside of the table: the table already has a section *"All nodes"*, make consistent usage of it

**TIP for reviewers:** the overall changes are pretty big, I suggest you to review the individual commits to have a better understanding of what has changed. Each commit is well scoped and documented.

**Note well:** I've been able to deploy a cluster on AWS with security rules mapped to the contents of this table. I didn't test dex/gangway, I'll do that later.

## Updated table

I've attached an image of rendered table to make lifer easier for the reviewers.

![new ports](https://user-images.githubusercontent.com/22728/62540704-7d47c880-b858-11e9-8ca2-122cc3246480.png)

## Open questions

I hope I didn't miss anything. Please tell me if some ports should be added/removed.

### CRI-O streaming

I found limited information about it: [here](https://github.com/cri-o/cri-o/blob/master/docs/crio.conf.5.md#crioapi-table)

Is it related with streaming the logs to a central aggregator (CC @innobead and @saschagrunert )?

On a cluster I deployed the `stream_address` is empty, meaning this streaming endpoint is not being used at all.

**Proposal:** let's drop it from the table and document somewhere else its usage (maybe the section about logging). Note well: we should also tell our users the CRI-O stream is **not** going to be secure unless a bunch of `stream_tls_{cert, key, ca}` related options are set.

## Need help reviewing the table

I think the following people can help with the review process:

* @ereslibre 
* @saschagrunert 
* @mrostecki 
* @innobead 