### PR TITLE
Add a section about the HW prerequisites to the AutoYaST deployment.

### DIFF
--- a/adoc/deployment-bare-metal.adoc
+++ b/adoc/deployment-bare-metal.adoc
@@ -25,6 +25,12 @@ you must adjust the {ay} file to your needs according to the requirements.
 Refer to the official {ay} documentation for more information: link:https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html[{ay} Guide].
 ====
 
+==== Hardware Prerequisites
+
+Deployment with {ay} will require a minimum *disk size of 40GB*.
+10GB out of that total space will be reserved for container images without any workloads,
+and the for the root partition (30GB) and the EFI system partition (200MB).
+
 === {ay} preparation
 
 . Obtain example {ay} file from `/usr/share/caasp/autoyast/bare-metal/autoyast.xml`


### PR DESCRIPTION
Fix for https://github.com/SUSE/doc-caasp/issues/281