### PR TITLE
Fix ssh-add command

### DIFF
--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -294,7 +294,7 @@ export VSPHERE_SERVER="<server_address"
 export VSPHERE_USER="<username>"
 export VSPHERE_PASSWORD="<password>"
 
-ssh-add -i <path_to_ssh_key_from_tfvars>
+ssh-add <path_to_private_ssh_key_from_tfvars>
 ----
 
 Run terraform to create the required machines for use with `skuba`:


### PR DESCRIPTION
The `ssh-add` command does to allow a `-i` flag - just the path to the private key is needed:

```sh
ssh-add -i ~/.ssh/id_rsa
unknown option -- i
```