### PR TITLE
Remove comment character in from of the heading

### DIFF
--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -1,4 +1,4 @@
-//= Cluster Management
+= Cluster Management
 
 Cluster management refers to several processes in the life cycle of a cluster and
 its individual nodes: bootstrapping, joining, removing and resetting nodes.


### PR DESCRIPTION
`= Cluster management` heading was starting with a comment.

Fixes #371 