### PR TITLE
Removed references to 'reset' sub command

### DIFF
--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -1,7 +1,7 @@
 //= Cluster Management
 
 Cluster management refers to several processes in the life cycle of a cluster and
-its individual nodes: bootstrapping, joining, removing and resetting nodes.
+its individual nodes: bootstrapping, joining and removing nodes.
 For maximum automation and ease {productname} uses the `skuba` tool,
 which simplifies Kubernetes cluster creation and reconfiguration.
 
@@ -66,14 +66,6 @@ so it is the safest way to remove the node.
 
 [source,bash]
 skuba node remove <node-name>
-
-== Resetting nodes
-
-The `skuba node reset` command enables you to reset a node to a state prior to `join` or `bootstrap` being run.
-Use this command to retry a failed `bootstrap` or `join` on a node or if the node has to be evacuated from the cluster.
-
-[source,bash]
-skuba node reset --target <IP/FQDN> --sudo --user <user-name>
 
 == Reconfiguring nodes
 


### PR DESCRIPTION
This is a doc update to match this PR which removed the 'reset' subcommand:  https://github.com/SUSE/skuba/pull/553