### PR TITLE
Add information about loadbalancer and master nodes

### DIFF
--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -35,6 +35,12 @@ this is necessary for all node operations.
 - `--target <IP/FQDN>` is the IP address or FQDN of the relevant machine.
 - `<node-name>` is how you decide to name the node you are adding.
 
+[IMPORTANT]
+====
+New master nodes that were not initially planned within Terraform's configuration they have
+to be manually added to your Loadbalancer's configuration.
+====
+
 To add a new *worker* node, you would run something like:
 
 [source,bash]
@@ -66,6 +72,12 @@ so it is the safest way to remove the node.
 
 [source,bash]
 skuba node remove <node-name>
+
+[IMPORTANT]
+====
+After the removal of a master node you have to manually delete its entries
+from your Loadbalancer's configuration.
+====
 
 == Reconfiguring nodes
 

--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -37,8 +37,8 @@ this is necessary for all node operations.
 
 [IMPORTANT]
 ====
-New master nodes that were not initially planned within Terraform's configuration they have
-to be manually added to your Loadbalancer's configuration.
+New master nodes that you didn't initially include in your Terraform's configuration have
+to be manually added to your load balancer's configuration.
 ====
 
 To add a new *worker* node, you would run something like:
@@ -76,7 +76,7 @@ skuba node remove <node-name>
 [IMPORTANT]
 ====
 After the removal of a master node you have to manually delete its entries
-from your Loadbalancer's configuration.
+from your load balancer's configuration.
 ====
 
 == Reconfiguring nodes


### PR DESCRIPTION
When we are adding a master node that was not originally planned
to be added from the beginning of the cluster (e.g. buy new 10
servers) they will **NOT** be automatically added to the config
of the loadbalancer.

The same happens when you delete a master node. There will be
stale entries pointing to a non-cluster resource unless the use
manually removes them.