### PR TITLE
Updated to state permanent removal of node

### DIFF
--- a/adoc/admin-cluster-management.adoc
+++ b/adoc/admin-cluster-management.adoc
@@ -56,8 +56,9 @@ https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/#use-kubec
 
 [IMPORTANT]
 ====
-Nodes removed with this method can not be added back to the cluster. You must
-reinstall the entire node and then join it again to the cluster.
+Nodes removed with this method can not be added back to the cluster or any other 
+skuba-initiated cluster. You must reinstall the entire node and then join it 
+again to the cluster.
 ====
 
 The `skuba node remove` command serves to *permanently* remove nodes.

--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -612,7 +612,9 @@ For removing a node, the following command has to be executed:
 ----
 
 If the node to be removed is a master, specific actions will be
-automatically executed, like removing the etcd member from the cluster.
+automatically executed, like removing the etcd member from the cluster. 
+Note that this node cannot be added back to the cluster or any other 
+skuba-initiated kubernetes cluster without reinstalling first.
 
 === Monitoring
 


### PR DESCRIPTION
Clearly state permanent node removal when using `skuba node remove`.  Addresses [AG#699](https://github.com/SUSE/avant-garde/issues/699).

In conjunction with skuba [PR#627](https://github.com/SUSE/skuba/pull/627) which adds the same node to `skuba node remove` manpage.