### PR TITLE
Remove obsolete docker and flannel references

### DIFF
--- a/adoc/admin-security-psp.adoc
+++ b/adoc/admin-security-psp.adoc
@@ -73,8 +73,10 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.unprivileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: runtime/default
+    apparmor.security.beta.kubernetes.io/defaultProfileName: runtime/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: false

--- a/adoc/architecture-updates.adoc
+++ b/adoc/architecture-updates.adoc
@@ -33,11 +33,13 @@ The output of the command will look like that:
 
 [source,bash]
 ----
-NAME                OS-IMAGE     KERNEL-VERSION                CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES
-ag-master-caasp-0   SLE 15 SP1   4.12.14-1p150.12.28-default   docker://18.6.1     yes           yes
-ag-master-caasp-1   SLE 15 SP1   4.12.14-1p150.12.28-default   docker://18.6.1     yes           yes
-ag-master-caasp-2   SLE 15 SP1   4.12.14-1p150.12.28-default   docker://18.6.1     yes           yes
-ag-worker-caasp-0   SLE 15 SP1   4.12.14-1p150.12.28-default   docker://18.6.1     yes           yes
+NAME        OS-IMAGE                              KERNEL-VERSION           KUBELET-VERSION   CONTAINER-RUNTIME   HAS-UPDATES   HAS-DISRUPTIVE-UPDATES
+master00   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
+master01   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
+master02   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
+worker00   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
+worker01   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
+worker02   SUSE Linux Enterprise Server 15 SP1   4.12.14-197.15-default   v1.15.2           cri-o://1.15.0      no            no
 ----
 
 ==== Node reboots

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -401,15 +401,20 @@ or
 ----
 # kubectl get pods --all-namespaces
 
-NAMESPACE     NAME                                READY     STATUS    RESTARTS   AGE
-kube-system   coredns-86c58d9df4-5zftb            1/1       Running   0          2m
-kube-system   coredns-86c58d9df4-fct4m            1/1       Running   0          2m
-kube-system   etcd-my-master                      1/1       Running   0          1m
-kube-system   kube-apiserver-my-master            1/1       Running   0          1m
-kube-system   kube-controller-manager-my-master   1/1       Running   0          1m
-kube-system   kube-flannel-ds-amd64-b6krs         1/1       Running   0          53s
-kube-system   kube-flannel-ds-amd64-v7kt7         1/1       Running   0          2m
-kube-system   kube-proxy-5qxnt                    1/1       Running   0          2m
-kube-system   kube-proxy-746ws                    1/1       Running   0          53s
-kube-system   kube-scheduler-my-master            1/1       Running   0          1m
+NAMESPACE     NAME                                    READY     STATUS    RESTARTS   AGE
+kube-system   coredns-86c58d9df4-5zftb                1/1       Running   0          2m
+kube-system   coredns-86c58d9df4-fct4m                1/1       Running   0          2m
+kube-system   etcd-my-master                          1/1       Running   0          1m
+kube-system   kube-apiserver-my-master                1/1       Running   0          1m
+kube-system   kube-controller-manager-my-master       1/1       Running   0          1m
+kube-system   cilium-operator-7d6ddddbf5-dmbhv        1/1       Running   0          51s
+kube-system   cilium-qjt9h                            1/1       Running   0          53s
+kube-system   cilium-szkqc                            1/1       Running   0          2m
+kube-system   kube-proxy-5qxnt                        1/1       Running   0          2m
+kube-system   kube-proxy-746ws                        1/1       Running   0          53s
+kube-system   kube-scheduler-my-master                1/1       Running   0          1m
+kube-system   kured-ztnfj                             1/1       Running   0          2m
+kube-system   kured-zv696                             1/1       Running   0          2m
+kube-system   oidc-dex-55fc689dc-b9bxw                1/1       Running   0          2m
+kube-system   oidc-gangway-7b7fbbdbdf-ll6l8           1/1       Running   0          2m
 ----


### PR DESCRIPTION
This removes obsolete docker references to kubectl `outputs` and in the `PSP`

Signed-off-by: lcavajani <lcavajani@suse.com>