### PR TITLE
Fix psp example

### DIFF
--- a/adoc/admin-security-psp.adoc
+++ b/adoc/admin-security-psp.adoc
@@ -73,8 +73,8 @@ kind: PodSecurityPolicy
 metadata:
   name: suse.caasp.psp.unprivileged
   annotations:
-    seccomp.security.alpha.kubernetes.io/allowedProfileNames: docker/default
-    seccomp.security.alpha.kubernetes.io/defaultProfileName: docker/default
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: runtime/default
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: runtime/default
 spec:
   # Privileged
   privileged: false

--- a/adoc/admin-security-role-management.adoc
+++ b/adoc/admin-security-role-management.adoc
@@ -22,7 +22,7 @@ delete::
 Delete resources.
 
 deletecollection::
-Delete a collection of CronJob.
+Delete a collection of a resource (can only be invoked using the kubernetes `API`).
 
 get::
 Display individual resource.


### PR DESCRIPTION
The reference to `docker/default` is replaced with `runtime/default`.