### PR TITLE
Missing a reboot command after transactional-update shell

### DIFF
--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -379,7 +379,9 @@ entrypoint.sh bundle exec rails runner \
 <prompt>transactional update #</prompt> <command>echo "gencert \"kubectl-client-cert\" \"kubectl-client-cert\" \
     \"\$all_hostnames\" \"\$(ip_addresses)\"" >>/usr/share/caasp-container-manifests/gen-certs.sh</command>
 <prompt>transactional update # </prompt><command>/usr/share/caasp-container-manifests/gen-certs.sh</command>
-<prompt>transactional update # </prompt><command>exit</command></screen>
+<prompt>transactional update # </prompt><command>exit</command>
+&prompt.root.admin;<command>reboot</command>
+</screen>
     </tip>
    </step>
    <step>


### PR DESCRIPTION
The documentation is missing a reboot command after  files change in a
transactional-update shell. If the customer does not reboot the machine,
the changes will not be used. Possibly, the change will be lost after a
further update due a new snapshot will be created.

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>