### PR TITLE
Added disk provision type

### DIFF
--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -56,7 +56,7 @@ image::vmware_step5.png[width=80%,pdfwidth=80%]
 image::vmware_step6.png[width=80%,pdfwidth=80%]
 .. Select menu:CPU[2].
 .. Select menu:Memory[4096 MB].
-.. Select menu:New Hard disk[40GB].
+.. Select menu:New Hard disk[40GB], menu:New Hard disk[Disk Provisioning > Thin Provision].
 .. Select menu:New SCSI Controller[LSI Logic Parallel SCSI controller (default)] and change it to "VMware Paravirtualized".
 .. Select menu:New Network[VM Network], menu:New Network[Adapter Type > VMXNET3].
 +


### PR DESCRIPTION
Added disk provision type. Default set to `Thick Provision ...`, but requires `Thin Provision`.

Reference: https://github.com/SUSE/avant-garde/issues/807