### PR TITLE
Fix JeOS url

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -4,7 +4,7 @@
 // Media Locations
 :caasp_repo_url: http://download.suse.de/ibs/SUSE:/SLE-15-SP1:/Update:/Products:/CASP40/standard/
 :isofile: SLE-15-SP1-Installer-DVD-x86_64-GM-DVD1.iso
-:jeos_product_page_url: https://www.suse.com/products/server/jeos/
+:jeos_product_page_url: https://download.suse.com/Download?buildid=OE-3enq3uys~
 
 // Product Versions
 


### PR DESCRIPTION
fix #456

The official JeOS url contains SLE12 JeOS. Given we don't know how long
it will take for the page to be fixed and have the SLE15 JeOS, we better
use https://download.suse.com/Download?buildid=OE-3enq3uys~

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>