### PR TITLE
Add nfs-client into the SES requirements

### DIFF
--- a/adoc/admin-ses-integration.adoc
+++ b/adoc/admin-ses-integration.adoc
@@ -9,8 +9,8 @@ this chapter describes the steps required for successful integration.
 
 Before you start with integrating {ses}, you need to ensure the following:
 
-* The {productname} cluster must have `ceph-common` and `xfsprogs` installed on all nodes.
-You can check this by running `rpm -q ceph-common` and `rpm -q xfsprogs`.
+* The {productname} cluster must have `ceph-common`, `xfsprogs` and `nfs-client` installed on all nodes.
+You can check this by running `rpm -q ceph-common`, `rpm -q xfsprogs` and `rpm -q nfs-client`.
 * The {productname} cluster can communicate with all of the following {ses} nodes:
 master, monitoring nodes, OSD nodes and the metadata server (in case you need a shared file system).
 For more details refer to the {ses} documentation:


### PR DESCRIPTION
ceph-common and xfsprogs were already in the requirements chapter. We
were missing nfs-client.

This fixes #463 and partially fixes bsc#1144991

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>