### PR TITLE
Admission Controller

### DIFF
--- a/adoc/admin-security-access.adoc
+++ b/adoc/admin-security-access.adoc
@@ -1,0 +1,11 @@
+= Access Control
+
+Users access the API using `kubectl`, client libraries, or by making REST requests. Both human users and {kube} service accounts can be authorized for API access. When a request reaches the API, it goes through several stages, that can be explained with the following three questions:
+
+. Authentication: It answers to the question *who are you?* This is accomplished via client certificates, bearer tokens, an authenticating proxy, or HTTP basic auth to authenticate API requests through authentication plugins.
+
+. Authorization: It answers to the question *what kind of access do you have?* This is accomplished via RBAC API, that is a set of permissions for the previously authenticated user. Permissions are purely additive (there are no "deny" rules). A role can be defined within a namespace with a Role, or cluster-wide with a ClusterRole.
+
+. Admission Control: It answers to the question *what are you trying to do?* This is accomplished via admission controllers. They can modify (mutate) or validate (accept or reject) requests.
+
+Unlike authentication and authorization, if any admission controller rejects, then the request is immediately rejected.

--- a/adoc/admin-security-access.adoc
+++ b/adoc/admin-security-access.adoc
@@ -1,11 +1,11 @@
 = Access Control
 
-Users access the API using `kubectl`, client libraries, or by making REST requests. Both human users and {kube} service accounts can be authorized for API access. When a request reaches the API, it goes through several stages, that can be explained with the following three questions:
+Users access the API using `kubectl`, client libraries, or by making REST requests.
+Both human users and {kube} service accounts can be authorized for API access.
+When a request reaches the API, it goes through several stages, that can be explained with the following three questions:
 
-. Authentication: It answers to the question *who are you?* This is accomplished via client certificates, bearer tokens, an authenticating proxy, or HTTP basic auth to authenticate API requests through authentication plugins.
-
-. Authorization: It answers to the question *what kind of access do you have?* This is accomplished via RBAC API, that is a set of permissions for the previously authenticated user. Permissions are purely additive (there are no "deny" rules). A role can be defined within a namespace with a Role, or cluster-wide with a ClusterRole.
-
-. Admission Control: It answers to the question *what are you trying to do?* This is accomplished via admission controllers. They can modify (mutate) or validate (accept or reject) requests.
+. Authentication: *who are you?* This is accomplished via client certificates, bearer tokens, an authenticating proxy, or HTTP basic auth to authenticate API requests through authentication plugins.
+. Authorization: *what kind of access do you have?* This is accomplished via <<rbac>> API, that is a set of permissions for the previously authenticated user. Permissions are purely additive (there are no "deny" rules). A role can be defined within a namespace with a Role, or cluster-wide with a ClusterRole.
+. Admission Control: *what are you trying to do?* This is accomplished via <<admission>>. They can modify (mutate) or validate (accept or reject) requests.
 
 Unlike authentication and authorization, if any admission controller rejects, then the request is immediately rejected.

--- a/adoc/admin-security-admission.adoc
+++ b/adoc/admin-security-admission.adoc
@@ -1,0 +1,27 @@
+= Admission Controllers
+
+== Introduction
+
+After user authentication and authorization, *admission* takes place to complete the access control for the {kube} API. As the final step in the access control process, admission enhances the security layer by mandating a reasonable security baseline across a specific namespace or the entire cluster. The built-in {psp} admission controller is perhaps the most prominent example of it. Apart from the security aspect, admission controllers can enforce custom policies to adhere to certain best-practices such as having good labels, annotation, resource limits, or other settings. It is worth noticing that instead of only validating the request, admission controllers are also capable of fixing it by mutating it, such as automatically adding resource limits if the user forgets to.
+
+The admission is controlled by admission controllers which may only be configured by the cluster administrator. The admission control process proceeds in *two phases*:
+
+ . In the first phase, *mutating* admission controllers are run. If it's needed, they are empowered to automatically change the requested object to comply with certain cluster policies by making modifications to it.
+ . In the second phase, *validating* admission controllers are run. Based on the results of the previous mutating phase, an admission controller can either allow the request to proceed and reach `etcd` or deny it.
+
+[IMPORTANT]
+====
+If any of the controllers in either phase reject the request, the entire request is rejected immediately and an error is returned to the end-user.
+====
+
+== Admission controllers
+
+The complete list of admission controllers can be found at https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#what-does-each-admission-controller-do
+
+The default admission controllers enabled in {product} are:
+
+----
+"NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota, NodeRestriction,PodSecurityPolicy"
+----
+
+Any modification prior to the creation of the cluster will be overwritten by these settings. The ability to add or remove individual admission controllers will be provided within the next upcoming releases of the {product}.

--- a/adoc/admin-security-admission.adoc
+++ b/adoc/admin-security-admission.adoc
@@ -1,27 +1,48 @@
+[[admission]]
 = Admission Controllers
 
 == Introduction
 
-After user authentication and authorization, *admission* takes place to complete the access control for the {kube} API. As the final step in the access control process, admission enhances the security layer by mandating a reasonable security baseline across a specific namespace or the entire cluster. The built-in {psp} admission controller is perhaps the most prominent example of it. Apart from the security aspect, admission controllers can enforce custom policies to adhere to certain best-practices such as having good labels, annotation, resource limits, or other settings. It is worth noticing that instead of only validating the request, admission controllers are also capable of fixing it by mutating it, such as automatically adding resource limits if the user forgets to.
+After user authentication and authorization, *admission* takes place to complete the access control for the {kube} API.
+As the final step in the access control process, admission enhances the security layer by mandating a reasonable security baseline across a specific namespace or the entire cluster.
+The built-in {psp} admission controller is perhaps the most prominent example of it.
 
-The admission is controlled by admission controllers which may only be configured by the cluster administrator. The admission control process proceeds in *two phases*:
+Apart from the security aspect, admission controllers can enforce custom policies to adhere to certain best-practices such as having good labels, annotation, resource limits, or other settings.
+It is worth noting that instead of only validating the request, admission controllers are also capable of "fixing" a request by mutating it, such as automatically adding resource limits if the user forgets to.
 
- . In the first phase, *mutating* admission controllers are run. If it's needed, they are empowered to automatically change the requested object to comply with certain cluster policies by making modifications to it.
- . In the second phase, *validating* admission controllers are run. Based on the results of the previous mutating phase, an admission controller can either allow the request to proceed and reach `etcd` or deny it.
+The admission is controlled by admission controllers which may only be configured by the cluster administrator. The admission control process happens in *two phases*:
+
+. In the first phase, *mutating* admission controllers are run. They are empowered to automatically change the requested object to comply with certain cluster policies by making modifications to it if needed.
+. In the second phase, *validating* admission controllers are run. Based on the results of the previous mutating phase, an admission controller can either allow the request to proceed and reach `etcd` or deny it.
 
 [IMPORTANT]
 ====
 If any of the controllers in either phase reject the request, the entire request is rejected immediately and an error is returned to the end-user.
 ====
 
-== Admission controllers
+== Configured admission controllers
+
+[IMPORTANT]
+====
+Any modification of this list prior to the creation of the cluster will be overwritten by these default settings.
+
+The ability to add or remove individual admission controllers will be provided with one of the upcoming releases of {productname}.
+====
 
 The complete list of admission controllers can be found at https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#what-does-each-admission-controller-do
 
-The default admission controllers enabled in {product} are:
+The default admission controllers enabled in {productname} are:
 
-----
-"NamespaceLifecycle,LimitRanger,ServiceAccount,TaintNodesByCondition,Priority,DefaultTolerationSeconds,DefaultStorageClass,PersistentVolumeClaimResize,MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota, NodeRestriction,PodSecurityPolicy"
-----
-
-Any modification prior to the creation of the cluster will be overwritten by these settings. The ability to add or remove individual admission controllers will be provided within the next upcoming releases of the {product}.
+. `NamespaceLifecycle`
+. `LimitRanger`
+. `ServiceAccount`
+. `TaintNodesByCondition`
+. `Priority`
+. `DefaultTolerationSeconds`
+. `DefaultStorageClass`
+. `PersistentVolumeClaimResize`
+. `MutatingAdmissionWebhook`
+. `ValidatingAdmissionWebhook`
+. `ResourceQuota`
+. `NodeRestriction`
+. `PodSecurityPolicy`

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -1,3 +1,4 @@
+[[rbac]]
 = Role Based Access Control (RBAC)
 
 == Introduction

--- a/adoc/book_admin.adoc
+++ b/adoc/book_admin.adoc
@@ -1,7 +1,7 @@
 include::attributes.adoc[]
 include::entities.adoc[]
 
-= {productname} {productversion} Administration Guide: This guide describes general and specialized administrative tasks for {productname} {productversion}.
+= Administration Guide: This guide describes general and specialized administrative tasks for {productname} {productversion}.
 Markus Napp; Nora Kořánová
 :sectnums:
 :doctype: book
@@ -39,6 +39,8 @@ include::admin-cluster-management.adoc[Cluster management,leveloffset=+1]
 
 == Security
 
+include::admin-security-access.adoc[leveloffset=+2]
+
 include::admin-security-role-management.adoc[leveloffset=+2]
 
 include::admin-security-user-group-management.adoc[Group Management, leveloffset=+2]
@@ -48,6 +50,8 @@ include::admin-security-rbac.adoc[Role Based Access Control (RBAC),leveloffset=+
 include::admin-security-ldap.adoc[External LDAP, leveloffset=+2]
 
 include::admin-security-psp.adoc[Pod Security Policies,leveloffset=+2]
+
+include::admin-security-admission.adoc[leveloffset=+2]
 
 include::admin-security-certificates.adoc[Certificates,leveloffset=+2]
 


### PR DESCRIPTION
This PR adds the documentation required for https://github.com/SUSE/skuba/pull/697

It adds two new pages:

* `adoc/admin-security-access.adoc`: a page describing the security concepts and implications across CaaSP with admission controllers, PSP and RBAC all in place 


* `adoc/admin-security-admission.adoc`: a new page that describes the admission controller(s) and which ones we use

PS: I expect these pages to grow after proper research and for the admission plugins.