### PR TITLE
Remove superfluous productname from guide titles.

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -16,7 +16,7 @@
 //Counting upwards from 0, tied to maintenance release
 :productpatch: 0
 :prerelease:
-:productversion: {productmajor}.{productminor}.{productpatch} {prerelease}
+:productversion: {productmajor}.{productminor}.{productpatch}
 :github_url: https://github.com/SUSE/doc-caasp
 
 // Component Versions

--- a/adoc/book_admin.adoc
+++ b/adoc/book_admin.adoc
@@ -1,7 +1,7 @@
 include::attributes.adoc[]
 include::entities.adoc[]
 
-= {productname} {productversion} Administration Guide: This guide describes general and specialized administrative tasks for {productname} {productversion}.
+= Administration Guide: This guide describes general and specialized administrative tasks for {productname} {productversion}.
 Markus Napp; Nora Kořánová
 :sectnums:
 :doctype: book

--- a/adoc/book_architecture.adoc
+++ b/adoc/book_architecture.adoc
@@ -1,7 +1,7 @@
 include::attributes.adoc[]
 include::entities.adoc[]
 
-= {productname} {productversion} Architecture Description
+= Architecture Description: This guide describes the architecture of {productname} {productversion}.
 :doctype: book
 :sectnums:
 :sectnumlevels: 4

--- a/adoc/book_deployment.adoc
+++ b/adoc/book_deployment.adoc
@@ -1,7 +1,7 @@
 include::attributes.adoc[]
 include::entities.adoc[]
 
-= {productname} {productversion} Deployment Guide: This guide describes deployment for {productname} {productversion}.
+= Deployment Guide: This guide describes deployment for {productname} {productversion}.
 Markus Napp; Nora Kořánová
 :sectnums:
 :doctype: book

--- a/adoc/book_quickstart.adoc
+++ b/adoc/book_quickstart.adoc
@@ -1,7 +1,7 @@
 include::attributes.adoc[]
 include::entities.adoc[]
 
-= {productname} {productversion} QuickStart Guide: This guide describes quick deployment for {productname} {productversion}.
+= QuickStart Guide: This guide describes quick deployment for {productname} {productversion}.
 Markus Napp; Nora Kořánová
 :sectnums:
 :doctype: book


### PR DESCRIPTION
Why is this needed? 
The list of guides at https://documentation.suse.com/suse-caasp/4/ also includes product name and version number for each guide, for example: _SUSE CaaS Platform 4.0.0 Administration Guide_, it should instead only say _Administration Guide_. The `{productname} {productversion}` information is in the subtitle anyway. 