### PR TITLE
typo: fix kubectl typo

### DIFF
--- a/xml/admin_integration_ses.xml
+++ b/xml/admin_integration_ses.xml
@@ -128,7 +128,7 @@ spec:
     <para>
      Verify that the pod exists and its status:
     </para>
-<screen>&prompt.user;<command>kubectl get po</command></screen>
+<screen>&prompt.user;<command>kubectl get pod</command></screen>
    </step>
    <step>
     <para>


### PR DESCRIPTION
Fixes a typo in the kubectl to get the pods