### PR TITLE
Fixed cephfs example output

### DIFF
--- a/adoc/admin-ses-integration.adoc
+++ b/adoc/admin-ses-integration.adoc
@@ -497,7 +497,7 @@ kubectl get pod
 
 ----
 kubectl exec -it CONTAINER_NAME -- df -k ...
-/dev/rbd0           1003      21       962   3% /mnt/cephfsvol
+172.28.0.6:6789,172.28.0.14:6789,172.28.0.7:6789:/  59572224       0  59572224   0% /mnt/cephfsvol
 ...
 ----
 


### PR DESCRIPTION
Example mounts to rbd, fixed to output mount to monitor nodes.

Reference:
* https://github.com/SUSE/avant-garde/issues/836