### PR TITLE
Fixed wrong persistStateInterval unit

### DIFF
--- a/adoc/admin-centralized-logging.adoc
+++ b/adoc/admin-centralized-logging.adoc
@@ -179,7 +179,7 @@ Options with empty default values are set as not specified.
 |logs.kubernetesUserNamespaces.enabled|enables Kubernetes user namespaces logs|false
 |logs.kubernetesUserNamespaces.exclude|excludes Kubernetes logs for specific namespaces|- ""
 |logs.osSystem.enabled|enables OS logs (auditd, kernel, wicked, zypper)|true
-|persistStateInterval|sets time interval (seconds) for data state persistency|100
+|persistStateInterval|sets interval (number-of-messages) for data state persistency|100
 |queue.enabled|enables Rsyslog queue|false
 |queue.maxDiskSpace|sets maximum Rsyslog queue disk space in bytes|2147483648
 |queue.size|sets Rsyslog queue size in bytes|50000
@@ -193,5 +193,5 @@ Options with empty default values are set as not specified.
 |server.tls.clientKey|sets TLS client key|
 |server.tls.enabled|enables TLS|false
 |server.tls.permittedPeer|sets a list of TLS/fingerprints or TLS/names with permission to access the server|
-|server.tls.rootCa|specifies TLS root cetrificate authority|
+|server.tls.rootCa|specifies TLS root certificate authority|
 |===


### PR DESCRIPTION
Fixed wrong persistStateInterval unit. 

According to Rsyslog module - [imjournal](https://www.rsyslog.com/doc/v8-stable/configuration/modules/imjournal.html), the unit for persistStateInterval is `number-of-messages`.

Other Changes:
* Fixed typo.

Reference: 
* https://github.com/SUSE/avant-garde/issues/835

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>