### PR TITLE
Fix certificate path in CPI instructions

### DIFF
--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -149,7 +149,7 @@ You can find the required parameters in OpenStack RC File v3.
     tenant-id=<OS_PROJECT_ID> // <4>
     domain-name=<OS_USER_DOMAIN_NAME> // <5>
     region=<OS_REGION_NAME> // <6>
-    ca-file="/etc/ssl/certs/SUSE_Trust_Root.pem" // <7>
+    ca-file="/etc/pki/trust/anchors/SUSE_Trust_Root.pem" // <7>
     [LoadBalancer]
     lb-version=v2 // <8>
     subnet-id=<PRIVATE_SUBNET_ID> // <9>

--- a/adoc/deployment-ecp.adoc
+++ b/adoc/deployment-ecp.adoc
@@ -88,9 +88,9 @@ This is required so all the deployed nodes can automatically register with {scc}
 # Enable CPI integration with OpenStack
 cpi_enable = true
 
-# Used to specify the name of to your custom CA file located in /etc/ssl/certs.
+# Used to specify the name of to your custom CA file located in /etc/pki/trust/anchors/.
 # Upload CUSTOM_CA_FILE to this path on nodes before joining them to your cluster.
-#ca_file = "/etc/ssl/certs/<CUSTOM_CA_FILE>"
+#ca_file = "/etc/pki/trust/anchors/<CUSTOM_CA_FILE>"
 ----
 . Now you can deploy the nodes by running:
 +


### PR DESCRIPTION
If certificate is uploaded to /etc/ssl/certs it disappears after cluster update. This means kubernetes looses access to openstack and cluster dies.

PR for https://github.com/SUSE/doc-caasp/issues/537