### PR TITLE
Add AWS docs

### DIFF
--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -81,6 +81,8 @@ Versioning scheme: `x.y.z`
 * VMware ESXi {vmware_version}
 * Bare Metal
 
+Deployment on Amazon Web Services (AWS) is currently tech preview.
+
 == Supported Architectures
 
 * x86_64
@@ -328,9 +330,90 @@ it's needed to have a local RMT server mirroring the CaaSP
 repositories, a mirror of the SUSE container registry and a mirror of
 the SUSE helm chart repository.
 
+[[architecture.aws]]
+=== AWS Deployment
+
+The AWS deployment created by our {tf} template files leads to the
+creation of the infrastructure described in the next paragraphs.
+
+==== Network
+
+All the infrastructure is created inside of a user specified AWS region.
+All the resources are currently located inside of the same availability
+region.
+
+A dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
+with two subnets (_"public"_ and _"private"_) is created by the {tf} template
+files.
+
+Instances inside of the public subnet have
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[Elasic IP addresses]
+associated, hence they are reachable from the internet.
+
+Instances inside of the private subnet are not reachable from the internet.
+However they can still reach external resources; for example they can still
+perform operations like downloading updates and pulling container images from
+external container registries.
+
+Communication between the public and the private subnet is allowed.
+
+All the control plane instances are currently located inside of the public
+subnet. Worker instances are inside of the private subnet.
+
+Both control plane and worker nodes have tailored
+link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html[Security Groups]
+assigned to them. These are based on the networking requirements described
+in <<sysreq.networking>>.
+
+==== Load Balancer
+
+The {tf} template files take care of creating a
+link:https://aws.amazon.com/elasticloadbalancing/[Classic Load Balancer]
+which exposes the Kubernetes API service deployed on the control plane
+nodes.
+
+The load balancer exposes the following ports:
+
+* `6443`: Kubernetes API server
+* `32000`: Dex (OIDC Connect)
+* `32001`: Gangway (RBAC Authenticate)
+
+[[architecture.aws.vpc_peering]]
+==== Join already existing VPCs
+
+The {tf} template files allow the user to have the
+{productname} VPC join one or more existing VPCs.
+
+This is achieved by the creation of
+link:https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html[VPC peering links]
+and dedicated
+link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html[Route tables].
+
+This feature allows {productname} to access and be accessed by resources defined
+inside of other VPCs. For example, this capability can be used to register all
+the {productname} instances against a SUSE Manager server running inside of a
+private VPC.
+
+Current limitations:
+
+* The VPCs must belong to the same AWS region.
+* The VPCs must be owned by the same user who is creating the {productname}
+infrastructure via {tf}.
+
+==== IAM profiles
+
+The
+link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws[AWS Cloud Provider]
+integration for Kubernetes requires special
+link:https://aws.amazon.com/iam/[IAM] profiles to be associated with the control
+plane and worker instances.
+
+{tf} can create these profiles or can leverage existing ones. It all depends on
+the rights of the user invoking {tf}.
+
 === Control plane nodes certificates
 
-Certificates are stored under /etc/kubernetes/pki on the control plane nodes.
+Certificates are stored under `/etc/kubernetes/pki` on the control plane nodes.
 
 ==== CA certificates
 

--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -80,8 +80,8 @@ Versioning scheme: `x.y.z`
 * SUSE OpenStack Cloud 8
 * VMware ESXi {vmware_version}
 * Bare Metal
+* Amazon Web Services (technological preview)
 
-Deployment on Amazon Web Services (AWS) is currently tech preview.
 
 == Supported Architectures
 
@@ -330,86 +330,6 @@ it's needed to have a local RMT server mirroring the CaaSP
 repositories, a mirror of the SUSE container registry and a mirror of
 the SUSE helm chart repository.
 
-[[architecture.aws]]
-=== AWS Deployment
-
-The AWS deployment created by our {tf} template files leads to the
-creation of the infrastructure described in the next paragraphs.
-
-==== Network
-
-All the infrastructure is created inside of a user specified AWS region.
-All the resources are currently located inside of the same availability
-region.
-
-A dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
-with two subnets (_"public"_ and _"private"_) is created by the {tf} template
-files.
-
-Instances inside of the public subnet have
-link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[Elasic IP addresses]
-associated, hence they are reachable from the internet.
-
-Instances inside of the private subnet are not reachable from the internet.
-However they can still reach external resources; for example they can still
-perform operations like downloading updates and pulling container images from
-external container registries.
-
-Communication between the public and the private subnet is allowed.
-
-All the control plane instances are currently located inside of the public
-subnet. Worker instances are inside of the private subnet.
-
-Both control plane and worker nodes have tailored
-link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html[Security Groups]
-assigned to them. These are based on the networking requirements described
-in <<sysreq.networking>>.
-
-==== Load Balancer
-
-The {tf} template files take care of creating a
-link:https://aws.amazon.com/elasticloadbalancing/[Classic Load Balancer]
-which exposes the Kubernetes API service deployed on the control plane
-nodes.
-
-The load balancer exposes the following ports:
-
-* `6443`: Kubernetes API server
-* `32000`: Dex (OIDC Connect)
-* `32001`: Gangway (RBAC Authenticate)
-
-[[architecture.aws.vpc_peering]]
-==== Join already existing VPCs
-
-The {tf} template files allow the user to have the
-{productname} VPC join one or more existing VPCs.
-
-This is achieved by the creation of
-link:https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html[VPC peering links]
-and dedicated
-link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html[Route tables].
-
-This feature allows {productname} to access and be accessed by resources defined
-inside of other VPCs. For example, this capability can be used to register all
-the {productname} instances against a SUSE Manager server running inside of a
-private VPC.
-
-Current limitations:
-
-* The VPCs must belong to the same AWS region.
-* The VPCs must be owned by the same user who is creating the {productname}
-infrastructure via {tf}.
-
-==== IAM profiles
-
-The
-link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws[AWS Cloud Provider]
-integration for Kubernetes requires special
-link:https://aws.amazon.com/iam/[IAM] profiles to be associated with the control
-plane and worker instances.
-
-{tf} can create these profiles or can leverage existing ones. It all depends on
-the rights of the user invoking {tf}.
 
 === Control plane nodes certificates
 

--- a/adoc/book_deployment.adoc
+++ b/adoc/book_deployment.adoc
@@ -54,7 +54,7 @@ include::deployment-preparation.adoc[Deployment Preparations, leveloffset=+1]
 
 include::deployment-ecp.adoc[SUSE OpenStack Cloud Instructions, leveloffset=+1]
 
-//include::deployment-aws.adoc[Amazon AWS Cloud Instructions, leveloffset=+1]
+include::deployment-aws.adoc[Amazon AWS Cloud Instructions, leveloffset=+1]
 
 include::deployment-vmware.adoc[VMware Deployment Instructions, leveloffset=+1]
 

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -46,7 +46,7 @@ subnet. Worker instances are inside of the private subnet.
 Both control plane and worker nodes have tailored
 link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html[Security Groups]
 assigned to them. These are based on the networking requirements described
-in <<sysreq.networking>>.
+in <<sysreq-networking>>.
 
 ==== Load Balancer
 

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -89,8 +89,8 @@ requires your credentials. These can be obtained by following these steps:
 
 * Log in to the AWS console.
 * Click on your username in the upper right hand corner to reveal the drop-down menu.
-* Click on My Security Credentials.
-* Click Create Access Key on the Security Credentials tab.
+* Click on menu:My Security Credentials[].
+* Click menu:Create Access Key[] on the "Security Credentials" tab.
 * Note down the newly created _Access_ and _Secret_ keys.
 
 === Deploying the Infrastructure

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -1,6 +1,6 @@
 == Deployment on Amazon AWS
 
-Deployment on Amazon Web Services (AWS) is currently tech preview.
+Deployment on Amazon Web Services (AWS) is currently a tech preview.
 
 .Preparation Required
 [NOTE]
@@ -10,7 +10,7 @@ You must have completed <<deployment.preparations>> to proceed.
 
 You will use {tf} to deploy the whole infrastructure described in
 <<architecture-aws>>. Then you will use the `skuba` tool to bootstrap the
-{kube} cluster on top of those.
+{kube} cluster on top of it.
 
 
 [[architecture-aws]]
@@ -21,25 +21,17 @@ creation of the infrastructure described in the next paragraphs.
 
 ==== Network
 
-All the infrastructure is created inside of a user specified AWS region.
-All the resources are currently located inside of the same availability
+All of the infrastructure is created inside of a user specified AWS region.
+The resources are currently all located inside of the same availability
 zone.
 
-A dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
-with two subnets (_"public"_ and _"private"_) is created by the {tf} template
-files.
-
-Instances inside of the public subnet have
+The {tf} template files create a dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
+with *two subnets*: "public" and "private". Instances inside of the *public subnet* have
 link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[Elasic IP addresses]
-associated, hence they are reachable from the internet.
-
-Instances inside of the private subnet are not reachable from the internet.
+associated, hence they are reachable from the internet. Instances inside of the *private subnet* are not reachable from the internet.
 However they can still reach external resources; for example they can still
 perform operations like downloading updates and pulling container images from
-external container registries.
-
-Communication between the public and the private subnet is allowed.
-
+external container registries. Communication between the public and the private subnet is allowed.
 All the control plane instances are currently located inside of the public
 subnet. Worker instances are inside of the private subnet.
 
@@ -62,7 +54,7 @@ The load balancer exposes the following ports:
 * `32001`: Gangway (RBAC Authenticate)
 
 [[architecture-aws-vpc-peering]]
-==== Join already existing VPCs
+==== Join Already Existing VPCs
 
 The {tf} template files allow the user to have the
 {productname} VPC join one or more existing VPCs.
@@ -74,7 +66,7 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html[Rout
 
 This feature allows {productname} to access and be accessed by resources defined
 inside of other VPCs. For example, this capability can be used to register all
-the {productname} instances against a SUSE Manager server running inside of a
+the {productname} instances against a {susemgr} server running inside of a
 private VPC.
 
 Current limitations:
@@ -83,17 +75,14 @@ Current limitations:
 * The VPCs must be owned by the same user who is creating the {productname}
 infrastructure via {tf}.
 
-==== IAM profiles
+==== IAM Profiles
 
 The
 link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws[AWS Cloud Provider]
-integration for Kubernetes requires special
+integration for {kube} requires special
 link:https://aws.amazon.com/iam/[IAM] profiles to be associated with the control
-plane and worker instances.
-
-{tf} can create these profiles or can leverage existing ones. It all depends on
-the rights of the user invoking {tf}.
-
+plane and worker instances. {tf} can create these profiles or can leverage existing ones.
+It all depends on the rights of the user invoking {tf}.
 
 The {tf} link:https://www.terraform.io/docs/providers/aws/index.html[AWS provider]
 requires your credentials. These can be obtained by following these steps:
@@ -104,7 +93,7 @@ requires your credentials. These can be obtained by following these steps:
 * Click Create Access Key on the Security Credentials tab.
 * Note down the newly created _Access_ and _Secret_ keys.
 
-=== Deploying the infrastructure
+=== Deploying the Infrastructure
 
 On the management machine, find the {tf} template files for AWS in
 `/usr/share/caasp/terraform/aws`. These files have been installed as part of
@@ -161,13 +150,13 @@ terraform apply
 ----
 
 Check the output for the actions to be taken. Type "yes" and confirm with
-`Enter` when ready.
-Terraform will now provision all the cluster infrastructure.
+kbd:[Enter] when ready.
+{tf} will now provision all the cluster infrastructure.
 
-.Public IPs for nodes
+.Public IPs for Nodes
 [IMPORTANT]
 ====
-`skuba` cannot currently access nodes through a bastion host, so all
+`skuba` currently cannot access nodes through a bastion host, so all
 the nodes in the cluster must be directly reachable from the machine where
 `skuba` is being run.
 `skuba` could be run from one of the master nodes or from a pre-existing bastion
@@ -175,23 +164,23 @@ host located inside of a joined VPC as described in
 <<architecture-aws-vpc-peering>>.
 ====
 
-.Note down IP/FQDN for nodes
+.Note Down IP/FQDN For the Nodes
 [IMPORTANT]
 ====
 The IP addresses and FQDN of the generated machines will be displayed in the
-terraform output during the cluster node deployment. You need these information
+{tf} output during the cluster node deployment. You need these information
 later to deploy {productname}.
 
 These information can be obtained at any time by executing the
 `terraform output` command within the directory from which you executed
-terraform.
+{tf}.
 ====
 
-=== Logging in to the Cluster Nodes
+=== Logging into the Cluster Nodes
 
 Connecting to the cluster nodes can be accomplished only via SSH key-based
 authentication thanks to the ssh-public key injection done earlier via
-cloud-init. You can use the predefined `ec2-user` user to log in.
+`cloud-init`. You can use the predefined `ec2-user` user to log in.
 
 If the ssh-agent is running in the background, run:
 

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -1,12 +1,99 @@
 == Deployment on Amazon AWS
 
+Deployment on Amazon Web Services (AWS) is currently tech preview.
+
 .Preparation Required
 [NOTE]
+====
 You must have completed <<deployment.preparations>> to proceed.
+====
 
 You will use {tf} to deploy the whole infrastructure described in
-<<architecture.aws>>. Then you will use the `skuba` tool to bootstrap the
+<<architecture-aws>>. Then you will use the `skuba` tool to bootstrap the
 {kube} cluster on top of those.
+
+
+[[architecture-aws]]
+=== AWS Deployment
+
+The AWS deployment created by our {tf} template files leads to the
+creation of the infrastructure described in the next paragraphs.
+
+==== Network
+
+All the infrastructure is created inside of a user specified AWS region.
+All the resources are currently located inside of the same availability
+region.
+
+A dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
+with two subnets (_"public"_ and _"private"_) is created by the {tf} template
+files.
+
+Instances inside of the public subnet have
+link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html[Elasic IP addresses]
+associated, hence they are reachable from the internet.
+
+Instances inside of the private subnet are not reachable from the internet.
+However they can still reach external resources; for example they can still
+perform operations like downloading updates and pulling container images from
+external container registries.
+
+Communication between the public and the private subnet is allowed.
+
+All the control plane instances are currently located inside of the public
+subnet. Worker instances are inside of the private subnet.
+
+Both control plane and worker nodes have tailored
+link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html[Security Groups]
+assigned to them. These are based on the networking requirements described
+in <<sysreq.networking>>.
+
+==== Load Balancer
+
+The {tf} template files take care of creating a
+link:https://aws.amazon.com/elasticloadbalancing/[Classic Load Balancer]
+which exposes the Kubernetes API service deployed on the control plane
+nodes.
+
+The load balancer exposes the following ports:
+
+* `6443`: Kubernetes API server
+* `32000`: Dex (OIDC Connect)
+* `32001`: Gangway (RBAC Authenticate)
+
+[[architecture-aws-vpc-peering]]
+==== Join already existing VPCs
+
+The {tf} template files allow the user to have the
+{productname} VPC join one or more existing VPCs.
+
+This is achieved by the creation of
+link:https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html[VPC peering links]
+and dedicated
+link:https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html[Route tables].
+
+This feature allows {productname} to access and be accessed by resources defined
+inside of other VPCs. For example, this capability can be used to register all
+the {productname} instances against a SUSE Manager server running inside of a
+private VPC.
+
+Current limitations:
+
+* The VPCs must belong to the same AWS region.
+* The VPCs must be owned by the same user who is creating the {productname}
+infrastructure via {tf}.
+
+==== IAM profiles
+
+The
+link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws[AWS Cloud Provider]
+integration for Kubernetes requires special
+link:https://aws.amazon.com/iam/[IAM] profiles to be associated with the control
+plane and worker instances.
+
+{tf} can create these profiles or can leverage existing ones. It all depends on
+the rights of the user invoking {tf}.
+
 
 The {tf} link:https://www.terraform.io/docs/providers/aws/index.html[AWS provider]
 requires your credentials. These can be obtained by following these steps:
@@ -85,7 +172,7 @@ the nodes in the cluster must be directly reachable from the machine where
 `skuba` is being run.
 `skuba` could be run from one of the master nodes or from a pre-existing bastion
 host located inside of a joined VPC as described in
-<<architecture.aws.vpc_peering>>.
+<<architecture-aws-vpc-peering>>.
 ====
 
 .Note down IP/FQDN for nodes

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -4,95 +4,118 @@
 [NOTE]
 You must have completed <<deployment.preparations>> to proceed.
 
-You will use {tf} to deploy the required master and worker cluster nodes (plus a load
-balancer) and then use the `skuba` tool to bootstrap the {kube} cluster on
-top of those.
+You will use {tf} to deploy the whole infrastructure described in
+<<architecture.aws>>. Then you will use the `skuba` tool to bootstrap the
+{kube} cluster on top of those.
 
-. Download the AWS credentials
-.. Log in to the AWS console.
-.. Click on your username in the upper right hand corner to reveal the drop-down menu.
-.. Click on My Security Credentials.
-.. Click Create Access Key on the Security Credentials tab.
-.. Note down the newly created _Access_ and _Secret_ keys.
+The {tf} link:https://www.terraform.io/docs/providers/aws/index.html[AWS provider]
+requires your credentials. These can be obtained by following these steps:
 
-=== Deploying the Cluster Nodes
+* Log in to the AWS console.
+* Click on your username in the upper right hand corner to reveal the drop-down menu.
+* Click on My Security Credentials.
+* Click Create Access Key on the Security Credentials tab.
+* Note down the newly created _Access_ and _Secret_ keys.
 
-. On the management machine, find the {tf} template files for AWS in
-`/usr/share/caasp/terraform/aws` (which was installed as part of the management
-pattern (`sudo zypper in -t pattern SUSE-CaaSP-Management`)).
+=== Deploying the infrastructure
+
+On the management machine, find the {tf} template files for AWS in
+`/usr/share/caasp/terraform/aws`. These files have been installed as part of
+the management pattern (`sudo zypper in -t pattern SUSE-CaaSP-Management`).
+
 Copy this folder to a location of your choice as the files need adjustment.
-+
+
 ----
 mkdir -p ~/caasp/deployment/
 cp -r /usr/share/caasp/terraform/aws/ ~/caasp/deployment/
 cd ~/caasp/deployment/aws/
 ----
-. Once the files are copied, rename the `terraform.tfvars.example` file to
+
+Once the files are copied, rename the `terraform.tfvars.example` file to
 `terraform.tfvars`:
-+
+
 ----
-mv terraform.tfvars.example terraform.tfvars
+cp terraform.tfvars.example terraform.tfvars
 ----
-. Edit the `terraform.tfvars` file and add/modify the following variables:
-+
+
+Edit the `terraform.tfvars` file and add/modify the following variables:
+
 include::deployment-terraform-example.adoc[tags=tf_aws]
-+
+
 [TIP]
 ====
-You can set timezone in before deploying the nodes by modifying the files:
+You can set timezone and other parameters before deploying the nodes
+by modifying the cloud-init template:
 
 * `~/caasp/deployment/aws/cloud-init/cloud-init.yaml.tpl`
 ====
-. Enter the registration code for your nodes in `~/caasp/deployment/aws/registration.auto.tfvars`:
-+
-Substitute `<CAASP_REGISTRATION_CODE>` for the code from <<registration_code>>.
-+
+
+You can enter the registration code for your nodes in
+`~/caasp/deployment/aws/registration.auto.tfvars` instead of the
+`terraform.tfvars` file.
+
+Substitute `CAASP_REGISTRATION_CODE` for the code from <<registration_code>>.
+
 [source,json]
 ----
 # SUSE CaaSP Product Key
 caasp_registry_code = "<CAASP_REGISTRATION_CODE>"
 ----
-+
-This is required so all the deployed nodes can automatically register with {scc} and retrieve packages.
-. Now you can deploy the nodes by running:
-+
+
+This is required so all the deployed nodes can automatically register
+with {scc} and retrieve packages.
+
+Now you can deploy the nodes by running:
+
 ----
 terraform init
 terraform plan
 terraform apply
 ----
-+
-Check the output for the actions to be taken. Type "yes" and confirm with Enter when ready.
-Terraform will now provision all the machines and network infrastructure for the cluster.
+
+Check the output for the actions to be taken. Type "yes" and confirm with
+`Enter` when ready.
+Terraform will now provision all the cluster infrastructure.
 
 .Public IPs for nodes
 [IMPORTANT]
 ====
 `skuba` cannot currently access nodes through a bastion host, so all
 the nodes in the cluster must be directly reachable from the machine where
-`skuba` is being run. We must also consider that `skuba` must use
-the external IPs as `--target` when initializing or joining the cluster,
-while we must specify the internal DNS names for registering the nodes
-in the cluster.
+`skuba` is being run.
+`skuba` could be run from one of the master nodes or from a pre-existing bastion
+host located inside of a joined VPC as described in
+<<architecture.aws.vpc_peering>>.
 ====
 
 .Note down IP/FQDN for nodes
 [IMPORTANT]
 ====
-The IP addresses of the generated machines will be displayed in the terraform
-output during the cluster node deployment. You need these IP addresses to
-deploy {productname} to the cluster.
+The IP addresses and FQDN of the generated machines will be displayed in the
+terraform output during the cluster node deployment. You need these information
+later to deploy {productname}.
 
-If you need to find an IP address later on, you can run `terraform output` within
-the directory you performed the deployment from the `~/caasp/deployment/aws` directory or
-perform the following steps:
-
-. Log in to the AWS Console and click on menu:Load Balancers[]. Find the one with the
-string you entered in the {tf} configuration above, for example `testing-lb`.
-. Note down the "DNS name".
-+
-. Now click on menu:Instances[].
-. Using the menu:Filter[] text box, enter the string you specified for `stack_name`
-in the `terraform.tfvars` file.
-. Find the `IPv4 Public IP` on each of the nodes of your cluster.
+These information can be obtained at any time by executing the
+`terraform output` command within the directory from which you executed
+terraform.
 ====
+
+=== Logging in to the Cluster Nodes
+
+Connecting to the cluster nodes can be accomplished only via SSH key-based
+authentication thanks to the ssh-public key injection done earlier via
+cloud-init. You can use the predefined `ec2-user` user to log in.
+
+If the ssh-agent is running in the background, run:
+
+----
+ssh ec2-user@<node-ip-address>
+----
+
+Without the ssh-agent running, run:
+
+----
+ssh ec2-user@<node-ip-address> -i <path-to-your-ssh-private-key>
+----
+
+Once connected, you can execute commands using password-less `sudo`.

--- a/adoc/deployment-aws.adoc
+++ b/adoc/deployment-aws.adoc
@@ -23,7 +23,7 @@ creation of the infrastructure described in the next paragraphs.
 
 All the infrastructure is created inside of a user specified AWS region.
 All the resources are currently located inside of the same availability
-region.
+zone.
 
 A dedicated Amazon Virtual Private Cloud (link:https://aws.amazon.com/vpc/[VPC])
 with two subnets (_"public"_ and _"private"_) is created by the {tf} template

--- a/adoc/deployment-bare-metal.adoc
+++ b/adoc/deployment-bare-metal.adoc
@@ -156,3 +156,4 @@ Please refer to: link:{docurl}single-html/caasp-admin/#_configuring_httphttps_pr
 
 In some environments you must configure the container runtime to access the container registries through a proxy.
 In this case, please refer to: {docurl}single-html/caasp-admin/#_configuring_httphttps_proxy_for_cri_o[{productname} Admin Guide: Configuring HTTP/HTTPS Proxy for CRI-O]
+====

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -510,6 +510,7 @@ To talk to your cluster, you must be in the `my-cluster` directory when running 
 [TIP]
 ====
 To make usage of {kube} tools easier, you can store a copy of the `admin.conf` file as link:{kubedoc}concepts/configuration/organize-cluster-access-kubeconfig/[kubeconfig].
+====
 
 [source,bash]
 ----
@@ -518,6 +519,7 @@ cp admin.conf ~/.kube/config
 ----
 
 [WARNING]
+====
 The configuration file contains sensitive information and must be handled in a secure fashion. Copying it to a shared user directory might grant access to unwanted users.
 ====
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -151,8 +151,28 @@ and automatically manage resources like the Load Balancer, Nodes (Instances), Ne
 and Storage services.
 
 If you want to enable cloud provider integration with different cloud platforms,
-initialize the cluster with the flag `--cloud-provider <CLOUD_PROVIDER>`.
-The only currently available option is `openstack`, but more options are planned:
+initialize the cluster with the flag `--cloud-provider <CLOUD PROVIDER>`.
+The only currently available options are `openstack` and `aws`,
+but more options are planned.
+
+.Cleanup
+[IMPORTANT]
+====
+By enabling CPI providers your Kubernetes cluster will be able to
+provision cloud resources on its own (eg: Load Balancers, Persistent Volumes).
+You will have to manually clean these resources before you destroy the cluster
+with {tf}.
+
+Not removing resources like Load Balancers created by the CPI will result in
+{tf} timing out during `destroy` operations.
+
+Persistent volumes created with the `retain` policy will exist inside of
+the external cloud infrastructure even after the cluster is removed.
+====
+
+====== OpenStack CPI
+
+Define the cluster using the following command:
 
 [source,bash]
 ----
@@ -236,6 +256,31 @@ After setting options in the `openstack.conf` file, please proceed with <<cluste
 When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the same node names that they have inside `Openstack`, as
 these names will be used by the `Openstack` cloud controller manager to reconcile node metadata.
 ====
+
+====== Amazon Web Services (AWS) CPI
+
+Define the cluster using the following command:
+
+[source,bash]
+----
+skuba cluster init --control-plane <LB IP/FQDN> --cloud-provider aws my-cluster
+----
+
+Running the above command will create a directory `my-cluster/cloud/aws` with a
+`README.md` file in it. No further configuration files are needed.
+
+The supported format and content can be found in the
+link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#aws[official Kubernetes documentation].
+
+
+[IMPORTANT]
+====
+When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the same node names that they have inside `AWS`, as
+these names will be used by the `AWS` cloud controller manager to reconcile node metadata.
+
+You can use the "private dns" values provided by the {tf} output.
+====
+
 
 ===== Integrate External LDAP TLS
 

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -7,8 +7,9 @@ Currently we support:
 * SUSE OpenStack Cloud 8
 * VMware ESXi {vmware_version}
 * Bare Metal x86_64
+* Amazon Web Services (technological preview)
 
-== Nodes
+=== Nodes
 
 You will need at least two machines:
 
@@ -206,6 +207,8 @@ Let's see two different examples:
 ----
 <1> Here we get a value of 28705usec (28ms) so the storage clearly does not meet the requirements.
 
+
+[[sysreq-networking]]
 === Networking
 
 The management workstation needs at least the following networking permissions:

--- a/adoc/deployment-terraform-example.adoc
+++ b/adoc/deployment-terraform-example.adoc
@@ -267,9 +267,9 @@ the product against {scc}.
 Mirroring Server.
 <11> `peer_vpc_ids`: List of already existing VPCs to join via dedicated VPC
 peering links.
-<11> `iam_profile_master`: Name of the IAM profile to associate with the control
+<12> `iam_profile_master`: Name of the IAM profile to associate with the control
 plane instance. Leave empty to have {tf} create it.
-<12> `iam_profile_worker`: Name of the IAM profile to associate with the worker
+<13> `iam_profile_worker`: Name of the IAM profile to associate with the worker
 instances. Leave empty to have {tf} create it.
 
 # end::tf_aws[]

--- a/adoc/deployment-terraform-example.adoc
+++ b/adoc/deployment-terraform-example.adoc
@@ -190,72 +190,86 @@ deployed machines.
 # end::tf_vmware[]
 
 
-// [[tf.aws]]
-// === Terraform AWS Configuration
-// # tag::tf_aws[]
-// [source,json]
-// ----
-// # prefix that all of the booted machines will use
-// # IMPORTANT, please enter unique identifier below as value of
-// # stack_name variable to not interfere with other deployments
-// stack_name = "caasp-v4" // <1>
-//
-// # AWS region
-// aws_region = "eu-central-1"  // <2>
-//
-// # AWS availability zone
-// aws_az = "eu-central-1a" // <3>
-//
-// # access key for AWS services
-// aws_access_key = "AKIXU..."  // <4>
-//
-// # secret key used for AWS services
-// aws_secret_key = "ORd..." // <5>
-//
-// # Number of master nodes
-// masters = 1 // <6>
-//
-// # Number of worker nodes
-// workers = 2 // <7>
-//
-// # Username for the cluster nodes. Must exist on base OS.
-// # EXAMPLE:
-// # username = "opensuse"
-// username = "opensuse" // <8>
-//
-// # ssh keys to inject into all the nodes
-// # EXAMPLE:
-// # authorized_keys = [
-// #   "ssh-rsa <KEY_CONTENT>"
-// # ]
-// authorized_keys = [ // <9>
-//   "ssh-rsa <KEY_CONTENT> example@example.com"
-// ]
-//
-// # to register CaaSP product please use ONLY ONE of the following method
-// #
-// # SUSE CaaSP Product Product Key:
-// #caasp_registry_code = ""  // <10>
-// #
-// # SUSE Repository Mirroring Server Name (FQDN):
-// #rmt_server_name = "rmt.example.com"  // <11>
-//
-// ----
-// <1> `stack_name`: Prefix for all machines of the cluster spawned by terraform.
-// *Note*: This string will be used to generate the human readable IDs in {soc}.
-// <2> `aws_region`: The region in AWS.
-// <3> `aws_az`: The availability zone in AWS.
-// <4> `aws_access_key`: AWS access key.
-// <5> `aws_secrert_key`: AWS secret key.
-// <6> `masters`: Number of master nodes to be deployed.
-// <7> `workers`: Number of worker nodes to be deployed.
-// <8> `username`: Login username for the nodes.
-// *Note*: the username must exist on the used base operating system. It will not be created.
-// <9> `authorized_keys`: List of ssh-public-keys that will be able to log in to the
-// deployed machines.
-// <10> `caasp_registry_code`: SUSE CaaSP Product Product Key for registering
-// the product against SUSE Customer Service.
-// <11> `caasp_registry_code`: register against a local SUSE Repository
-// Mirroring Server.
-//
-// # end::tf_aws[]
+[[tf.aws]]
+=== Terraform AWS Configuration
+# tag::tf_aws[]
+[source,json]
+----
+# prefix that all of the booted machines will use
+# IMPORTANT, please enter unique identifier below as value of
+# stack_name variable to not interfere with other deployments
+stack_name = "caasp-v4" // <1>
+
+# AWS region
+aws_region = "eu-central-1"  // <2>
+
+# AWS availability zone
+aws_az = "eu-central-1a" // <3>
+
+# access key for AWS services
+aws_access_key = "AKIXU..."  // <4>
+
+# secret key used for AWS services
+aws_secret_key = "ORd..." // <5>
+
+# Number of master nodes
+masters = 1 // <6>
+
+# Number of worker nodes
+workers = 2 // <7>
+
+# ssh keys to inject into all the nodes
+# EXAMPLE:
+# authorized_keys = [
+#   "ssh-rsa <key-content>"
+# ]
+authorized_keys = [ // <8>
+  "ssh-rsa <example_key> example@example.com"
+]
+
+# To register CaaSP product please use ONLY ONE of the following method
+#
+# SUSE CaaSP Product Product Key:
+#caasp_registry_code = ""  // <9>
+#
+# SUSE Repository Mirroring Server Name (FQDN):
+#rmt_server_name = "rmt.example.com"  // <10>
+
+# List of VPC IDs to join via VPC peer link
+#peer_vpc_ids = ["vpc-id1", "vpc-id2"] // <11>
+
+# Name of the IAM profile to associate to control plane nodes
+# Leave empty to have terraform create one.
+# This is required to have AWS CPI support working properly.
+#
+# Note well: you must  have the right set of permissions.
+# iam_profile_master = "caasp-k8s-master-vm-profile" // <12>
+
+# Name of the IAM profile to associate to worker nodes.
+# Leave empty to have terraform create one.
+# This is required to have AWS CPI support working properly.
+#
+# Note well: you must  have the right set of permissions.
+#iam_profile_worker = "caasp-k8s-worker-vm-profile" // <13>
+----
+<1> `stack_name`: Prefix for all machines of the cluster spawned by terraform.
+<2> `aws_region`: The region in AWS.
+<3> `aws_az`: The availability zone in AWS.
+<4> `aws_access_key`: AWS access key.
+<5> `aws_secrert_key`: AWS secret key.
+<6> `masters`: Number of master nodes to be deployed.
+<7> `workers`: Number of worker nodes to be deployed.
+<8> `authorized_keys`: List of ssh-public-keys that will be able to log into
+the deployed machines.
+<9> `caasp_registry_code`: {productname} Product Key for registering
+the product against {scc}.
+<10> `caasp_registry_code`: register against a local SUSE Repository
+Mirroring Server.
+<11> `peer_vpc_ids`: List of already existing VPCs to join via dedicated VPC
+peering links.
+<11> `iam_profile_master`: Name of the IAM profile to associate with the control
+plane instance. Leave empty to have {tf} create it.
+<12> `iam_profile_worker`: Name of the IAM profile to associate with the worker
+instances. Leave empty to have {tf} create it.
+
+# end::tf_aws[]


### PR DESCRIPTION
**WARNING: DO NOT MERGE**  - wait for the green light from either @flavio or @jordimassaguerpla - these docs reference things that are not yet shipped to our customers.

# What this is about

Extend the AWS docs to reflect the latest changes. Re-enable them into the official docs.

# Final warning
I wasn't able to render the **whole** docs on my computer, I hope the cross-doc links are working as expected.