### PR TITLE
Add info about disabling IPv6 bsc#1152810

### DIFF
--- a/adoc/book_quickstart.adoc
+++ b/adoc/book_quickstart.adoc
@@ -28,5 +28,7 @@ include::deployment-ecp.adoc[ECP Instructions]
 
 include::deployment-bootstrap.adoc[Bootstrapping,leveloffset=+1]
 
+include::deployment-cilium.adoc[Cilium]
+
 //GNU Licenses
 include::common_legal.adoc[Legal]

--- a/adoc/book_quickstart.adoc
+++ b/adoc/book_quickstart.adoc
@@ -13,6 +13,7 @@ Markus Napp; Nora Kořánová
 :imagesdir: images/
 :experimental:
 :docinfo: shared,private-head
+:deployment_scenario: quick
 
 include::common_disclaimer.adoc[Disclaimer]
 
@@ -28,7 +29,6 @@ include::deployment-ecp.adoc[ECP Instructions]
 
 include::deployment-bootstrap.adoc[Bootstrapping,leveloffset=+1]
 
-include::deployment-cilium.adoc[Cilium]
 
 //GNU Licenses
 include::common_legal.adoc[Legal]

--- a/adoc/deployment-cilium.adoc
+++ b/adoc/deployment-cilium.adoc
@@ -41,7 +41,7 @@ https://cilium.readthedocs.io/en/v1.5/gettingstarted/memcached/
 Making security policies on clusters on AWS::
 https://cilium.readthedocs.io/en/v1.5/gettingstarted/aws/
 
-[[cilium.disable_ipv6]]
+[[cilium-disable-ipv6]]
 ==== Disable IPv6
 
 . Switch to the cluster file directory (e.g `my-cluster`).

--- a/adoc/deployment-cilium.adoc
+++ b/adoc/deployment-cilium.adoc
@@ -40,3 +40,40 @@ https://cilium.readthedocs.io/en/v1.5/gettingstarted/memcached/
 
 Making security policies on clusters on AWS::
 https://cilium.readthedocs.io/en/v1.5/gettingstarted/aws/
+
+[[cilium.disable_ipv6]]
+==== Disable IPv6
+
+. Switch to the cluster file directory (e.g `my-cluster`).
+
+. In the cilium file `./addons/cni/cilium.yaml`, edit the args for the container
+with the name `cilium-agent` within the DaemonSet `cilium` to add "--enable-ipv6=false".
+This part should look like this (the args are subject to changes):
++
+[source,yaml]
+----
+      containers:
+      - image: registry.suse.com/caasp/v4/cilium
+        imagePullPolicy: IfNotPresent
+        name: cilium-agent
+        command: [ "cilium-agent" ]
+        args:
+          - "--debug=$(CILIUM_DEBUG)"
+          - "--disable-envoy-version-check"
+          - "-t=vxlan"
+          - "--kvstore=etcd"
+          - "--kvstore-opt=etcd.config=/var/lib/etcd-config/etcd.config"
+          - "--disable-ipv4=$(DISABLE_IPV4)"
+          - "--container-runtime=crio"
+          - "--enable-ipv6=false"
+----
+
+. There is nothing to do if this configuration is modified before the
+bootstrap of the cluster as it will be automatically applied.
+If the cluster is already bootstrapped, it is required to apply the changes:
++
+[source,bash]
+----
+kubectl apply -f ./addons/cni/cilium.yaml
+----
+The cilium pods will then be recreated one by one with the new parameters.

--- a/adoc/deployment-cilium.adoc
+++ b/adoc/deployment-cilium.adoc
@@ -1,3 +1,4 @@
+
 == Network Security
 
 === Cilium

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -229,10 +229,12 @@ This is not sufficient because Cilium will still try to enable IPv6 since it is 
 The first option will result in IPv6 not being disabled and the second will lead to Cilium not being able to start.
 ====
 
+ifeval::['{deployment_scenario}' != 'quick']
 [IMPORTANT]
 ====
 If you really want to disable IPv6, refer to <<cilium-disable-ipv6>>.
 ====
+endif::[]
 
 ==== IP Addresses
 

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -203,12 +203,38 @@ The management workstation needs at least the following networking permissions:
 
 |===
 
-==== IP Addresses
+==== IPv6
 
 [WARNING]
 ====
-Using IPv6 addresses is currently not supported.
+Using IPv6 addresses is currently not supported but it is not disabled.
 ====
+
+A common practice to disable IPv6 at the node level is to configure the following kernel parameter:
+[source]
+----
+net.ipv6.conf.all.disable_ipv6 = 1
+net.ipv6.conf.default.disable_ipv6 = 1
+----
+
+An other common way is to disable IPv6 when the kernel start by passing the following kernel parameter to the bootloader (GRUB):
+[source]
+----
+ipv6.disable=1
+----
+
+[WARNING]
+====
+This is not sufficient because Cilium will still try to enable IPv6 since it is the default behaviour.
+The first option will result in IPv6 not being disabled and the second will lead to Cilium not being able to start.
+====
+
+[IMPORTANT]
+====
+If you really want to disable IPv6, refer to <<cilium.disable_ipv6>>.
+====
+
+==== IP Addresses
 
 All nodes must be assigned static IPv4 addresses, which must not be changed manually afterwards.
 

--- a/adoc/deployment-sysreqs.adoc
+++ b/adoc/deployment-sysreqs.adoc
@@ -231,7 +231,7 @@ The first option will result in IPv6 not being disabled and the second will lead
 
 [IMPORTANT]
 ====
-If you really want to disable IPv6, refer to <<cilium.disable_ipv6>>.
+If you really want to disable IPv6, refer to <<cilium-disable-ipv6>>.
 ====
 
 ==== IP Addresses


### PR DESCRIPTION
Here are the info on how to disable IPv6 without encouraging it...

@nkoranova @r0ckarong there is an issue with `cilium.disable_ipv6` reference, do you have an idea how to fix this ?

```
Building DC-caasp-admin
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-admin html  
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-admin pdf  
Building DC-caasp-architecture
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-architecture html  
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-architecture pdf  
Building DC-caasp-deployment
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-deployment html  
daps -d /daps_temp-98g5jg6V02/source/DC-caasp-deployment pdf  
Building DC-caasp-quickstart
/daps_temp-98g5jg6V02/source/build/.profiled/noprofile/caasp-quickstart.xml:367:89: error: IDREF "cilium.disable_ipv6" without matching ID
make: *** [validate] Error 1
/usr/share/daps/make/validate.mk:40: recipe for target 'validate' failed
Error: exit status 2
(Exiting d2d_runner) DC-caasp-quickstart has validation issues and cannot be built.
(Exiting d2d) Oh no. There are no documents for you.
```

https://github.com/SUSE/avant-garde/issues/920

Fixes bsc#1152810

Signed-off-by: lcavajani <lcavajani@suse.com>