### PR TITLE
Fix typo in ex-admin-security-groups-role.

### DIFF
--- a/xml/admin_security.xml
+++ b/xml/admin_security.xml
@@ -850,7 +850,7 @@ subjects:
   name: <replaceable>LDAP_GROUP_NAME</replaceable><co xml:id="co-admin-security-groups-ldap-group-name"/>
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-- kind: Role
+  kind: Role
   name: <replaceable>ROLE_NAME</replaceable><co xml:id="co-admin-security-groups-role-name"/>
   apiGroup: rbac.authorization.k8s.io</screen>
     <calloutlist>


### PR DESCRIPTION
Fixes typo  by removing "-" from "- kind: Role" in  Example 1.7: Binding a Group to a Role 