### PR TITLE
Fix etcdctl cluster-health command

### DIFF
--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -267,7 +267,6 @@ entrypoint.sh bundle exec rails runner \
   </para>
 <screen>&prompt.root;<command>set -a</command>
 &prompt.root;<command>source /etc/sysconfig/etcdctl</command>
-&prompt.root;<command>export ETCDCTL_API=3</command>
 &prompt.root;<command>etcdctl cluster-health</command></screen>
  </sect1>
 

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -265,8 +265,7 @@ entrypoint.sh bundle exec rails runner \
    Use SSH to log into one of the cluster nodes, for example your first master.
    The following command provides an example for using <command>etcdctl</command>.
   </para>
-<screen>&prompt.root;<command>set -a</command>
-&prompt.root;<command>source /etc/sysconfig/etcdctl</command>
+<screen>&prompt.root;<command>set -a; source /etc/sysconfig/etcdctl; set +a</command>
 &prompt.root;<command>etcdctl cluster-health</command></screen>
  </sect1>
 


### PR DESCRIPTION
The following PR fixes the `etcdctl cluster-health` instructions, as this command doesn't work with `ETCDCTL_API=3`:

```
Error: unknown command "cluster-health" for "etcdctl"
```

Simply removing the export will result in using the v2 API, as this will be defined while sourcing the `etcdctl` environment file.

Furthermore, the PR only turns the auto export attribute (`set -a`) on during sourcing to prevent subsequent variables from being exported automatically.