### PR TITLE
Mention other methods for exposing monitoring services

### DIFF
--- a/adoc/admin-monitoring-stack.adoc
+++ b/adoc/admin-monitoring-stack.adoc
@@ -80,7 +80,9 @@ In this example, the domains are named after the components they represent. `pro
 
 [IMPORTANT]
 ====
-Please make sure you have the <<nginx-ingress>> installed and configured.
+In order to provide additional security level by using TLS certificates please make sure you have the <<nginx-ingress>> installed and configured.
+
+If you don't need TLS you may use other methods for exposing these web services as native LBaaS in OpenStack, haproxy service or k8s native methods as port-forwarding or NodePort but this is out of scope of this document.
 ====
 
 === TLS


### PR DESCRIPTION
The documentation is still referring to nginx ingress controller and TLS but I think it is worth to mention also other methods for exposing P&G - esp. when the services are not reachable from outside.