### PR TITLE
Document skuba log verbosity max of 5

### DIFF
--- a/adoc/admin-troubleshooting.adoc
+++ b/adoc/admin-troubleshooting.adoc
@@ -345,12 +345,12 @@ After opening a Service Request (SR), you can upload the TAR archive to Global T
 
 == Debugging Cluster Deployment
 
-If the cluster deployment fails, please re-run the command again with setting verbosity level to 10 `-v=10`.
+If the cluster deployment fails, please re-run the command again with setting verbosity level to 5 `-v=5`.
 
 For example, if bootstraps the first master node of the cluster fails, re-run the command like
 [source,bash]
 ----
-skuba node bootstrap --user sles --sudo --target <IP/FQDN> <NODE_NAME> -v=10
+skuba node bootstrap --user sles --sudo --target <IP/FQDN> <NODE_NAME> -v=5
 ----
 
 However, if the `join` procedure fails at the last final steps, re-running it might _not_ help. To verify

--- a/adoc/deployment-preparation.adoc
+++ b/adoc/deployment-preparation.adoc
@@ -112,9 +112,24 @@ you must make sure to delete this file before creating the template.
 
 If two nodes are deployed with the same `machine-id`, they will not be correctly recognized by `skuba`.
 
-[TIP]
+[[machine-id-regen]]
+.Regenerating Machine ID
+[IMPORTANT]
 ====
-To manually generate the unique `machine-id` please refer to: <<machine-id-regen>>.
+In case you are not using {tf} or {ay} you must regenerate machine IDs manually.
+
+During the template preparation you will have removed the machine ID from the template image.
+This ID is required for proper functionality in the cluster and must be (re-)generated on each machine.
+
+Log in to each virtual machine created from the template and run:
+
+----
+dbus-uuidgen --ensure
+systemd-machine-id-setup
+systemctl restart systemd-journald
+----
+
+This will regenerate the `machine id` values for `DBUS` (`/var/lib/dbus/machine-id`) and `systemd` (`/etc/machine-id`) and restart the logging service to make use of the new IDs.
 ====
 
 === Installation Tools

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -297,24 +297,9 @@ the OS as needed.
 . You need to know the FQDN/IP for each of the created VMs during the bootstrap process
 . Continue with bootstrapping/joining of nodes
 
-[[machine-id-regen]]
-.Regenerating Machine ID
-[IMPORTANT]
+[TIP]
 ====
-In case you are not using {tf} or {ay} you must regenerate machine IDs manually.
-
-During the template preparation you will have removed the machine ID from the template image.
-This ID is required for proper functionality in the cluster and must be (re-)generated on each machine.
-
-Log in to each virtual machine created from the template and run:
-
-----
-dbus-uuidgen --ensure
-systemd-machine-id-setup
-systemctl restart systemd-journald
-----
-
-This will regenerate the `machine id` values for `DBUS` (`/var/lib/dbus/machine-id`) and `systemd` (`/etc/machine-id`) and restart the logging service to make use of the new IDs.
+To manually generate the unique `machine-id` please refer to: <<machine-id-regen>>.
 ====
 
 === Container Runtime Proxy


### PR DESCRIPTION
In an effort to make skuba consistent with upstream Kubernetes
logging practices, simplify the log level range from 10 to 5.

# Describe your changes
We will be making some further changes to skuba to simplify the number of log levels used.  This documentation is important to correctly represent that effort.

# Related Issues / Projects
Relates to: SUSE/avant-garde#493
See also SUSE/avant-garde#841