### PR TITLE
Reword k8s and addon upgrade instructions (Closes #664, Closes #667, Closes #643)

### DIFF
--- a/adoc/admin-updates.adoc
+++ b/adoc/admin-updates.adoc
@@ -17,6 +17,23 @@ Run `sudo zypper update` on the management workstation before any attempt to upd
 
 Updating of {kube} components is handled via `skuba`.
 
+The general procedure should look like this:
+
+. Update the packages and reboot your management workstation to get all the latest changes to skuba and it's dependencies
+. Run `skuba addon upgrade apply` on the management workstation
+.
+. Check if there are addon upgrades available for the current cluster
+. Upgrade all master nodes
+. Upgrade all worker nodes
+. Check if new addons are available for the new version
+.. If necessary upgrade master nodes again
+.. If necessary upgrade worker nodes again
+
+=== Update Management Workstation
+
+Run `sudo zypper up` on your management workstation to get the latest version of `skuba` and its dependencies.
+Reboot the machine to make sure that all system changes are correctly applied.
+
 === Generating an Overview of Available Platform Updates
 
 In order to get an overview of the updates available, you can run:
@@ -119,6 +136,12 @@ The control plane consists of these components:
 
 === Generating an Overview of Available Addon Updates
 
+[NOTE]
+====
+Due to changes to the way `skuba` handles addons some existing components might be shown as `new addon` in the status output.
+This is expected and no cause for concern. For any upgrade afterwards the addon will be considered known and only show available upgrades.
+====
+
 In order to get an overview of the addon updates available, you can run:
 
 ----
@@ -150,6 +173,12 @@ Latest Kubernetes version: 1.16.2
 Congratulations! Addons are already at the latest version available
 ----
 
+Before updating the nodes you must apply the addon upgrades to your management workstation.
+Please run:
+
+----
+skuba addon upgrade apply
+----
 
 == Updating Nodes
 
@@ -203,6 +232,12 @@ The upgrade via `skuba node upgrade apply` will:
 * upgrade the rest of the {kube} system stack (`kubelet`, `cri-o`).
 * restart services.
 ====
+
+=== Check for Upgrades to New Version
+
+Once you have upgraded all nodes, please run `skuba cluster upgrade plan` again.
+This will show if any upgrades are available that required the versions you just installed.
+If there are upgrades available please repeat the procedure until no more new upgrades are shown.
 
 == Base OS Updates
 

--- a/adoc/admin-updates.adoc
+++ b/adoc/admin-updates.adoc
@@ -17,21 +17,32 @@ Run `sudo zypper update` on the management workstation before any attempt to upd
 
 Updating of {kube} components is handled via `skuba`.
 
+[IMPORTANT]
+====
+Generally speaking: If you have other deployments not installed via {kube} or helm, update them last in the upgrade process.
+
+However, if your applications/deployments in their current versions are incompatible with the {kube} version that you are upgrading to,
+you must update these applications/deployments to a compatible version before attempting a cluster upgrade.
+
+Refer to the individual application/deployment for the requirements for {kube} version and dependencies.
+====
+
 The general procedure should look like this:
 
+. Check if all current versions of applications and deployments in the cluster will work on the new {kube} version to be installed
+.. If an application/deployment is incompatible with the new {kube} version, update the application/deployment before performing any of the other upgrade steps
 . Update the packages and reboot your management workstation to get all the latest changes to skuba, helm and their dependencies
-. Run `skuba addon upgrade plan` and then `skuba add upgrade apply` on the management workstation
+. Run `skuba addon upgrade plan` and then `skuba addon upgrade apply` on the management workstation
 . Apply all the configuration files that you modified for addons, the upgrade will have reset the configurations to defaults
 . Check if there are addon upgrades available for the current cluster using `skuba addon upgrade plan`
 .. Check if all the deployments in the cluster are compatible with the {kube} release that will be installed (refer to your individual deployments' documentation)
 If the deployment is not compatible you must update it to ensure it working with the updated {kube}.
-. Upgrade all master nodes by individually running `skuba node upgrade plan` and `skuba node upgrade apply`
-. Upgrade all worker nodes by individually running `skuba node upgrade plan` and `skuba node upgrade apply`
+. Upgrade all master nodes by sequentially running `skuba node upgrade plan` and `skuba node upgrade apply`
+.. Make sure to wait until all PODs/deployments/DaemonSets are up and running as expected before moving to the next node
+. Upgrade all worker nodes by sequentially running `skuba node upgrade plan` and `skuba node upgrade apply`
+.. Make sure to wait until all PODs/deployments/DaemonSets are up and running as expected before moving to the next node
 . Check if new addons are available for the new version using `skuba addon upgrade plan`
-.. If necessary upgrade master nodes and re-apply configuration changes again
-.. If necessary upgrade nodes and re-apply configuration changes again
-. Once all nodes are up to date, update helm and tiller and subsequently the helm deployments
-. If you have other deployments not installed via {kube} or helm, update them last
+. Once all nodes are up to date, update helm and tiller (as needed) and subsequently the helm deployments
 
 === Update Management Workstation
 

--- a/adoc/admin-updates.adoc
+++ b/adoc/admin-updates.adoc
@@ -19,15 +19,19 @@ Updating of {kube} components is handled via `skuba`.
 
 The general procedure should look like this:
 
-. Update the packages and reboot your management workstation to get all the latest changes to skuba and it's dependencies
-. Run `skuba addon upgrade apply` on the management workstation
-.
-. Check if there are addon upgrades available for the current cluster
-. Upgrade all master nodes
-. Upgrade all worker nodes
-. Check if new addons are available for the new version
-.. If necessary upgrade master nodes again
-.. If necessary upgrade worker nodes again
+. Update the packages and reboot your management workstation to get all the latest changes to skuba, helm and their dependencies
+. Run `skuba addon upgrade plan` and then `skuba add upgrade apply` on the management workstation
+. Apply all the configuration files that you modified for addons, the upgrade will have reset the configurations to defaults
+. Check if there are addon upgrades available for the current cluster using `skuba addon upgrade plan`
+.. Check if all the deployments in the cluster are compatible with the {kube} release that will be installed (refer to your individual deployments' documentation)
+If the deployment is not compatible you must update it to ensure it working with the updated {kube}.
+. Upgrade all master nodes by individually running `skuba node upgrade plan` and `skuba node upgrade apply`
+. Upgrade all worker nodes by individually running `skuba node upgrade plan` and `skuba node upgrade apply`
+. Check if new addons are available for the new version using `skuba addon upgrade plan`
+.. If necessary upgrade master nodes and re-apply configuration changes again
+.. If necessary upgrade nodes and re-apply configuration changes again
+. Once all nodes are up to date, update helm and tiller and subsequently the helm deployments
+. If you have other deployments not installed via {kube} or helm, update them last
 
 === Update Management Workstation
 
@@ -111,8 +115,7 @@ Component versions in master0
 ----
 
 It may happen that the {kube} version on the control plane is too outdated
-for the update to progress.
-In this case, you would get output similar to the following:
+for the update to progress. In this case, you would get output similar to the following:
 
 ----
 Current Kubernetes cluster version: 1.15.0


### PR DESCRIPTION
Rewrite the instructions based on the reports in #664 and #667 to run `skuba addon upgrade apply` on the management node before attempting upgrade of cluster nodes.