### PR TITLE
Fix broken links in v3.

### DIFF
--- a/xml/admin_administration.xml
+++ b/xml/admin_administration.xml
@@ -45,7 +45,7 @@
    </para>
    <para>
     If you are using &sle; 12 SP3 or 15.0, you must
-    <link xlink:href="https://www.suse.com/documentation/sled-15/book_quickstarts/data/sec_modules_installing.html">enable the PackageHub Extension</link>.
+    <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/art-modules.html#sec-modules-installing">enable the PackageHub Extension</link>.
    </para>
    <para>
     The instructions are identical for both versions.
@@ -203,7 +203,7 @@ cmd.run "<replaceable>df -h</replaceable>"</command>
    </para>
    <important>
    <para>
-    All nodes (including the cluster and nodes to be added) must be upgraded before adding. 
+    All nodes (including the cluster and nodes to be added) must be upgraded before adding.
     Failure to upgrade all nodes to the same software versions will result in orchestration failures.
     </para>
    <para>

--- a/xml/admin_integration_ses.xml
+++ b/xml/admin_integration_ses.xml
@@ -34,7 +34,7 @@
      monitoring nodes, OSD nodes and the metadata server, in case you need a
      shared file system. For more details regarding SES refer to the SES
      documentation, here: <link xlink:href=
-     "https://www.suse.com/documentation/suse-enterprise-storage/" />.
+     "https://documentation.suse.com/ses/6/" />.
     </para>
    </listitem>
    <listitem>

--- a/xml/admin_troubleshooting.xml
+++ b/xml/admin_troubleshooting.xml
@@ -40,7 +40,7 @@
    Request (SR), you can upload the TAR archive to Global Technical
    Support. It will help to locate the issue you reported and to assist
    you in solving the problem. For details, see <link xlink:href=
-   "https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_adm_support.html"
+   "https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#cha-adm-support"
    />.
   </para>
   <para>

--- a/xml/common_intro_available_doc_i.xml
+++ b/xml/common_intro_available_doc_i.xml
@@ -29,7 +29,7 @@
  <para>
   We provide HTML and PDF versions of our books in different languages.   Documentation for our products is available at
   <link
-  xlink:href="http://www.suse.com/documentation/"/>, where you can also
+  xlink:href="https://documentation.suse.com/"/>, where you can also
   find the latest updates and browse or download the documentation
   in various formats.
  </para>

--- a/xml/common_intro_feedback_i.xml
+++ b/xml/common_intro_feedback_i.xml
@@ -42,8 +42,8 @@
      We want to hear your comments about and suggestions for this manual and
      the other documentation included with this product. Use the User Comments
      feature at the bottom of each page in the online documentation or go to
-     <link xlink:href="http://www.suse.com/documentation/feedback.html"/> and
-     enter your comments there.
+     <link xlink:href="https://documentation.suse.com/"/> and
+     enter your comments in the Feedback form at the bottom of the page.
     </para>
    </listitem>
   </varlistentry>

--- a/xml/deployment_appendix.xml
+++ b/xml/deployment_appendix.xml
@@ -16,7 +16,7 @@
     <para/>
  <sect1 xml:id="deployment-appendix">
   <title>Installing an &Admin_Node; using &ay;</title>
-  
+
   <para/>
 
   <para>
@@ -34,9 +34,9 @@
   <screen>
 <xi:include href="autoyast_example_adminnode.xml" parse="text"/>
   </screen>
-  
+
   <para/>
-  
+
   <para>
    Copy the above and paste it into a file named <literal>autoyast.xml</literal>,
    then edit it as appropriate for your configuration. After you have prepared
@@ -48,11 +48,11 @@
    &worker_node; in <xref linkend="sec-deploy-nodes-worker-install-manual-autoyast"/>.
   </para>
   <para>
-   For more information about using and customizing &ay;, refer to 
-   <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/invoking_autoinst.html#commandline_ay"/>.
+   For more information about using and customizing &ay;, refer to
+   <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-autoyast/#invoking-autoinst"/>.
   </para>
   <para>
-   For more information about using pre-hashed passwords, refer to 
+   For more information about using pre-hashed passwords, refer to
    <xref linkend="sec-deploy-cloud-init-user-data-password"/>.
   </para>
  </sect1>

--- a/xml/deployment_configuration.xml
+++ b/xml/deployment_configuration.xml
@@ -183,7 +183,7 @@
     The content of the passed url is copied to
     <filename>/etc/cloud/cloud.cfg.d/91_kernel_cmdline_url.cfg</filename> and
     it is not overwritten even though the url changes. For details about
-    boot parameters, see <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_i_yast2_startup.html" />.
+    boot parameters, see <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-i-yast2-startup" />.
    </para>
 
    <sect3 xml:id="nocloud-datasource-images">
@@ -799,7 +799,7 @@ runcmd:
     </para>
     <para>
      Information on the possible configuration values can be found in the
-     <link xlink:href="https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html">&ay; Guide</link>.
+     <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/#book-autoyast">&ay; Guide</link>.
     </para>
    </step>
    <step>
@@ -837,11 +837,11 @@ runcmd:
   </para>
   <para>
    If you want to register your node at a &smt; server, refer to the
-   <emphasis>SMT Guide</emphasis> at <link xlink:href="https://www.suse.com/documentation/sles-12/book_smt/data/book_smt.html"/>.
+   <emphasis>SMT Guide</emphasis> at <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-smt/#book-smt"/>.
   </para>
   <para>
    If you want to register your node at a &rmt; server, refer to the
-   <emphasis>RMT Guide</emphasis> at <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/book_rmt.html"/>.
+   <emphasis>RMT Guide</emphasis> at <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/book-rmt.html"/>.
   </para>
   <note xml:id="sec-configuration-suseconnect-proxy">
    <title>Using a Proxy Server with Authentication</title>

--- a/xml/deployment_installing_nodes.xml
+++ b/xml/deployment_installing_nodes.xml
@@ -42,7 +42,7 @@
      Use <keycap>F2</keycap> to change the language for the installer. A
      corresponding keyboard layout is chosen automatically. See
      <link
-      xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_i_yast2_startup.html"
+      xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-i-yast2-startup"
      />
      for more information about changing boot options.
     </para>
@@ -111,7 +111,7 @@
          You must not lose the &rootuser; password! After you enter it here,
          the password cannot be retrieved. For more information, see
          <link
-          xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_i_yast2_user_root.html"
+          xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-i-yast2-user-root"
          />.
         </para>
        </warning>
@@ -159,7 +159,7 @@
        <para>
         For more information about <literal>NTP</literal>, refer to
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_netz_xntp.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#cha-netz-xntp"
         />
        </para>
       </listitem>
@@ -204,7 +204,7 @@
           <para>
            Opens the <guimenu>Expert Partitioner</guimenu> described in
            <link
-            xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_yast2_i_y2_part_expert.html"
+            xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-yast2-i-y2-part-expert"
            />.
           </para>
           <warning>
@@ -254,7 +254,7 @@
         This section shows the boot loader configuration. Changing the
         defaults is only recommended if really needed. For details, refer to
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_grub2.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#cha-grub2"
         />.
        </para>
       </listitem>
@@ -276,7 +276,7 @@
        </para>
        <para>
         For more information on configuring network connections, refer to
-        <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_basicnet_yast.html"/>.
+        <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#sec-basicnet-yast"/>.
        </para>
       </listitem>
      </varlistentry>
@@ -287,7 +287,7 @@
         &kdump; saves the memory image (<quote>core dump</quote>) to the file
         system in case the kernel crashes. This enables you to find the cause
         of the crash by debugging the dump file. For more information, see
-        <link xlink:href="https://www.suse.com/documentation/sles-12/book_sle_tuning/data/cha_tuning_kdump_basic.html"/> .
+        <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-tuning/#cha-tuning-kdump-basic"/> .
        </para>
        <warning>
         <title>&kdump; with large amounts of RAM</title>
@@ -324,7 +324,7 @@
         Information</guimenu>. In this screen you can also change
         <guimenu>Kernel Settings</guimenu>. See
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_tuning/data/cha_tuning_io.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-tuning/#cha-tuning-io"
         />
         for more information.
        </para>
@@ -1192,7 +1192,7 @@
         </para>
         <para>
          For more information, refer to
-         <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/invoking_autoinst.html#commandline_ay"/>.
+         <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-autoyast/#invoking-autoinst-options"/>.
         </para>
        </listitem>
       </varlistentry>
@@ -1204,7 +1204,7 @@
          <literal>ifcfg=eth0=dhcp</literal>. Make sure to replace
          <literal>eth0</literal> with the actual name of the interface that you
          want to use DHCP for. For manual configuration, refer to
-         <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/ay_adv_network.html"/>.
+         <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-autoyast/#ay-adv-network"/>.
         </para>
         <para>
          If you wish to define a static IP you can also use <command>ifcfg</command>.

--- a/xml/deployment_preparation.xml
+++ b/xml/deployment_preparation.xml
@@ -429,7 +429,7 @@ suse_caasp:
      Install an installation server that provides a DHCP, PXE and TFTP
      service. Additionally, you can provide the installation data on
      an HTTP or FTP server. For details, refer to the &sle; 12 Deployment Guide:
-     <link xlink:href="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_deployment/book_sle_deployment.html#cha.deployment.prep_boot"/>.
+     <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#cha-deployment-prep-boot"/>.
     </para>
     <para>
      You can directly use the <filename>initrd</filename> and

--- a/xml/deployment_scenarios.xml
+++ b/xml/deployment_scenarios.xml
@@ -273,7 +273,7 @@
    <title>RPM Package Repository Mirroring</title>
    <para>
     Mirroring of the RPM repositories is handled by the
-    <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/book_rmt.html">&rmtool;</link>
+    <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-rmt/#book-rmt">&rmtool;</link>
     for &sls; 15. The tool provides functionality that mirrors the upstream
     &suse; package repositories on the local network. This is intended to
     minimize reliance on &suse; infrastructure for updating large volumes of
@@ -376,7 +376,7 @@
     </para>
     <para>
      For more information on the requirements of a &sle; 15 server, refer to:
-     <link xlink:href="https://www.suse.com/documentation/sles-15/singlehtml/book_sle_deployment/book_sle_deployment.html#part.prep">Installation Preparation</link>.
+     <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-deployment/#part-prep">Installation Preparation</link>.
     </para>
     <variablelist>
      <varlistentry>
@@ -470,7 +470,7 @@
      <title>Provision Mirror Servers</title>
      <step>
       <para>
-       <link xlink:href="https://www.suse.com/documentation/sles-15/book_quickstarts/data/art_sle_installquick.html">Set
+       <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-installquick/#art-sle-installquick">Set
        up two &sls; 15 machines</link> one on the internal network and one on
        the air gapped network.
       </para>
@@ -478,7 +478,7 @@
      <step>
       <para>
        Make sure you have
-       <link xlink:href="https://www.suse.com/documentation/sles-15/book_sles_docker/data/preparation.html">enabled
+       <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-dockerquick/#Preparation">enabled
        the <filename>Containers</filename> module</link> on both servers.
       </para>
      </step>
@@ -628,7 +628,7 @@
      <step>
       <para>
        Install the &rmtool; on both mirror servers as described in
-       <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/cha_rmt_installation.html">these instructions</link>.
+       <link xlink:href="https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-rmt-installation.html">these instructions</link>.
       </para>
      </step>
      </procedure>
@@ -637,7 +637,7 @@
       <step>
        <para>
         Connect the external mirror to &scc; as described in
-        <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/sec_rmt_mirroring_credentials.html">these instructions</link>.
+        <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-rmt/#sec-rmt-mirroring-credentials">these instructions</link>.
        </para>
        <important>
         <title>Mirror Registration</title>
@@ -674,7 +674,7 @@
    <sect3 xml:id="sec-deploy-scenarios-airgap-rpm-repository-client">
     <title>Client Configuration</title>
     <para>
-     <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/cha_rmt_client.html">Follow these instructions</link>
+     <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-rmt/#cha-rmt-client">Follow these instructions</link>
      to configure all &productname; nodes to use the package repository mirror server in
      the air gapped network.
     </para>
@@ -687,7 +687,7 @@
   <sect2 xml:id="sec-deploy-scenarios-airgap-rpm-repository-update">
    <title>Updating RPM Repository Mirror</title>
    <para>
-    <link xlink:href="https://www.suse.com/documentation/sles-15/book_rmt/data/sec_rmt_mirroring_export_import.html">Follow these instructions</link>
+    <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-rmt/#sec-rmt-mirroring-export-import">Follow these instructions</link>
     to update the external server, transfer the data to a storage device, and
     use that device to update the air gapped server.
    </para>
@@ -738,7 +738,7 @@
      </para>
       <para>
       For more information you can refer to:
-      <link xlink:href="https://www.suse.com/documentation/sles-15/book_sles_docker/data/sec_docker_registry_definition.html">SLES15 - Docker Open Source Engine Guide: What is Docker Registry?</link>.
+      <link xlink:href="https://documentation.suse.com/sles/15-SP1/single-html/SLES-dockerquick/#sec-docker-registry-definition">SLES15 - Docker Open Source Engine Guide: What is Docker Registry?</link>.
      </para>
     </note>
 

--- a/xml/deployment_sysreqs.xml
+++ b/xml/deployment_sysreqs.xml
@@ -1125,7 +1125,7 @@
      <para>
       Microsoft Azure does not provide a time protocol service. Please
       refer to <link xlink:href=
-      "https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_netz_xntp.html"
+      "https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#cha-netz-xntp"
       > &sls; documentation</link> for more information about NTP
       configuration. No manual NTP configuration is required on the
       cluster nodes, they synchronize time with the &admin_node;.

--- a/xml/quick_install.xml
+++ b/xml/quick_install.xml
@@ -38,7 +38,7 @@
  <para>
   For these and other deployment scenarios, see the &productname; Deployment
   Guide at <link
-   xlink:href="https://www.suse.com/documentation/suse-caasp-3/book_caasp_deployment/data/book_caasp_deployment.html"/>.
+   xlink:href="https://documentation.suse.com/suse-caasp/3/single-html/caasp-deployment/index.html"/>.
  </para>
 
  <sect1 xml:id="sec-quick-install-admin">
@@ -62,7 +62,7 @@
      Use <keycap>F2</keycap> to change the language for the installer. A
      corresponding keyboard layout is chosen automatically. For more information
      about changing boot options, see <link
-      xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_i_yast2_startup.html"
+      xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-i-yast2-startup"
      />.
     </para>
     <informalfigure>
@@ -127,7 +127,7 @@
          You should ensure that you will not lose the &rootuser; password!
          After you entered it here, the password cannot be retrieved. See
          <link
-          xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_i_yast2_user_root.html"
+          xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-i-yast2-user-root"
          />
          for more information.
         </para>
@@ -166,7 +166,7 @@
        <para>
         For more information about <literal>NTP</literal>, refer to
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_netz_xntp.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#ha-netz-xntp"
         />
        </para>
       </listitem>
@@ -212,7 +212,7 @@
           <para>
            Opens the <guimenu>Expert Partitioner</guimenu> described in
            <link
-            xlink:href="https://www.suse.com/documentation/sles-12/book_sle_deployment/data/sec_yast2_i_y2_part_expert.html"
+            xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#sec-yast2-i-y2-part-expert"
            />
            .
           </para>
@@ -262,7 +262,7 @@
         This section shows the boot loader configuration. Changing the defaults
         is only recommended if really needed. Refer to
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/cha_grub2.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#cha-grub2"
         />
         for details.
        </para>
@@ -286,7 +286,7 @@
        <para>
         For more information on configuring network connections, refer to
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_admin/data/sec_basicnet_yast.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-admin/#sec-basicnet-yast"
         />
         .
        </para>
@@ -309,7 +309,7 @@
         system in case the kernel crashes. This enables you to find the cause
         of the crash by debugging the dump file. For more information, see
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_tuning/data/cha_tuning_kdump_basic.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-tuning/#cha-tuning-kdump-basic"
         />.
        </para>
        <warning>
@@ -347,7 +347,7 @@
         Information</guimenu>. In this screen you can also change
         <guimenu>Kernel Settings</guimenu>. For more information, see
         <link
-         xlink:href="https://www.suse.com/documentation/sles-12/book_sle_tuning/data/cha_tuning_io.html"
+         xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-tuning/#cha-tuning-io"
         />.
        </para>
       </listitem>
@@ -554,7 +554,7 @@
    You can start the setup via PXE. For the full procedure, refer to the &sle;
    12 Deployment Guide:
    <link
-    xlink:href="https://www.suse.com/documentation/sles-12/singlehtml/book_sle_deployment/book_sle_deployment.html#cha.deployment.prep_boot"
+    xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-deployment/#cha-deployment-prep-boot"
    />.
   </para>
 
@@ -653,7 +653,7 @@
         <para>
          Path to the &ay; file. For more information, refer to
          <link
-          xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/invoking_autoinst.html#commandline_ay"
+          xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-autoyast/#invoking-autoinst"
          />
         </para>
        </listitem>
@@ -666,7 +666,7 @@
          <literal>ifcfg=eth0=dhcp</literal>. Make sure to replace
          <literal>eth0</literal> with the actual name of the interface that you
          want to use DHCP for. For manual configuration, refer to
-         <link xlink:href="https://www.suse.com/documentation/sles-12/book_autoyast/data/ay_adv_network.html"/>.
+         <link xlink:href="https://documentation.suse.com/sles/12-SP4/single-html/SLES-autoyast/#ay-adv-network"/>.
         </para>
        </listitem>
       </varlistentry>


### PR DESCRIPTION
Replace all instances of https://www.suse.com/documentation/(...) with https://documentation.suse.com/(...).