### PR TITLE
Update vmware version in attributes file.

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -24,7 +24,7 @@
 // Component Versions
 
 :cilium_version: 1.5.3
-:envoy_version: 
+:envoy_version:
 :crio_version: 1.16.0
 :dex_version: 2.16.0
 :etcd_version: 3.3.15
@@ -32,7 +32,7 @@
 :kube_version: 1.16.2
 :kubedoc: https://v1-16.docs.kubernetes.io/docs/
 :kured_version: 1.2.0-rev4
-:vmware_version: 6.7.0.20000
+:vmware_version: 6.7
 :helm_tiller_version: 2.16.1
 
 // API versions


### PR DESCRIPTION
Based on [VMware documentation](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&details=1&operatingSystems=247&productNames=15&page=1&display_interval=10&sortColumn=Partner&sortOrder=Asc&testConfig=16), SLES 15 should be only compatible with VMware ESXi 6.7. Confirmed [with QA](https://chat.suse.de/channel/caasp-qa?msg=amvXnjnzEZsf6yRvT) and PM. 