### PR TITLE
4.0.3: Fix suse.com/doc links, point to doc.suse.com

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,7 +6,7 @@ image:https://travis-ci.org/SUSE/doc-caasp.svg?branch=adoc["Build Status", link=
 This is the source for the official SUSE CaaS Platform documentation
 
 Released versions of the documentation will be published at
-https://www.suse.com/documentation/ once available.
+https://documentation.suse.com/ once available.
 
 == Contributing
 

--- a/adoc/admin-cap-integration.adoc
+++ b/adoc/admin-cap-integration.adoc
@@ -20,7 +20,7 @@ sudo grub2-mkconfig -o /boot/grub2/grub.cfg
 sudo systemctl reboot
 ----
 * The {productname} cluster has no restrictions for {cap} ports.
-For more details refer to the {cap} documentation: https://www.suse.com/documentation/cloud-application-platform-1/book-cap-guides/data/book-cap-guides.html.
+For more details refer to the {cap} documentation: https://documentation.suse.com/suse-cap/1.5.1/.
 * `Helm` and `Tiller` are installed on the node where you run the `skuba` and `kubectl` commands. For instructions on how to install Helm and Tiller refer to <<helm_tiller_install>>.
 
 == Procedures

--- a/adoc/admin-ses-integration.adoc
+++ b/adoc/admin-ses-integration.adoc
@@ -13,7 +13,7 @@ You can check this by running `rpm -q ceph-common` and `rpm -q xfsprogs`.
 * The {productname} cluster can communicate with all of the following {ses} nodes:
 master, monitoring nodes, OSD nodes and the metadata server (in case you need a shared file system).
 For more details refer to the {ses} documentation:
-https://www.suse.com/documentation/suse-enterprise-storage/.
+https://documentation.suse.com/ses/.
 * The {ses} cluster has a pool with RADOS Block Device (RBD) enabled.
 
 == Procedures According to Type of Integration

--- a/adoc/admin-troubleshooting.adoc
+++ b/adoc/admin-troubleshooting.adoc
@@ -46,7 +46,7 @@ The result is a `TAR` archive of files. Each of the `*.txz` files should be give
 
 After opening a Service Request (SR), you can upload the `TAR` archives to {suse} Global Technical Support.
 
-The data will help to debug the issue you reported and assist you in solving the problem. For details, see https://www.suse.com/documentation/sles-15/book_sle_admin/data/cha_adm_support.html.
+The data will help to debug the issue you reported and assist you in solving the problem. For details, see https://documentation.suse.com/sles/15-SP1/single-html/SLES-admin/#cha-adm-support.
 
 == Cluster definition directory
 

--- a/adoc/common_intro_available_doc.adoc
+++ b/adoc/common_intro_available_doc.adoc
@@ -5,7 +5,7 @@
 
 
 We provide HTML and PDF versions of our books in different languages.
-Documentation for our products is available at http://www.suse.com/documentation/, where you can also find the latest updates and browse or download the documentation in various formats.
+Documentation for our products is available at https://documentation.suse.com, where you can also find the latest updates and browse or download the documentation in various formats.
 
 The following documentation is available for this product:
 

--- a/adoc/common_intro_feedback.adoc
+++ b/adoc/common_intro_feedback.adoc
@@ -9,11 +9,8 @@ For services and support options available for your product, refer to http://www
 +
 To report bugs for a product component, go to https://scc.suse.com/support/requests, log in, and click menu:Create New[]. 
 
-User Comments::
-We want to hear your comments about and suggestions for this manual and the other documentation included with this product.
-Use the User Comments feature at the bottom of each page in the online documentation or go to http://www.suse.com/documentation/feedback.html and enter your comments there.
-
 Mail::
-For feedback on the documentation of this product, you can also send a mail to ``doc-team@suse.com``.
+We want to hear your comments about and suggestions for this manual and the other documentation included with this product.
+For feedback on the documentation of this product, you can send a mail to ``doc-team@suse.com``.
 Make sure to include the document title, the product version and the publication date of the documentation.
 To report errors or suggest enhancements, provide a concise description of the problem and refer to the respective section number and page (or URL).

--- a/adoc/deployment-bare-metal.adoc
+++ b/adoc/deployment-bare-metal.adoc
@@ -27,7 +27,7 @@ This {ay} file should act as a guide and should be updated with your company's s
 To account for hardware/platform-specific setup criteria (legacy BIOS vs. (U)EFI, drive partitioning, networking, etc.),
 you must adjust the {ay} file to your needs according to the requirements.
 
-Refer to the official {ay} documentation for more information: link:https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html[{ay} Guide].
+Refer to the official {ay} documentation for more information: link:https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/[{ay} Guide].
 ====
 
 ==== Hardware Prerequisites
@@ -75,7 +75,7 @@ Your {productname} registration key can be used to both activate {sle} 15 SP1 an
 ====
 
 +
-Refer to the official {ay} documentation for more information: link:https://www.suse.com/documentation/sles-15/singlehtml/book_autoyast/book_autoyast.html[{ay} Guide].
+Refer to the official {ay} documentation for more information: link:https://documentation.suse.com/sles/15-SP1/single-html/SLES-autoyast/[{ay} Guide].
 . Host the {ay} files on a Web server reachable inside the network you are installing the cluster in.
 
 ==== Deploying with local {RMT} server
@@ -138,7 +138,7 @@ Provide `autoyast=https://[webserver/path/to/autoyast.xml]` during the {sle} 15 
 [NOTE]
 ====
 Use AutoYaST and make sure to use a staged frozen patchlevel via RMT/SUSE Manager to ensure a 100% reproducible setup.
-link:https://www.suse.com/documentation/sles-15/singlehtml/book_rmt/book_rmt.html#cha.rmt_client[RMT Guide]
+link:https://documentation.suse.com/sles/15-SP1/single-html/SLES-rmt/#cha-rmt-client[RMT Guide]
 ====
 
 Once the machines have been installed using the {ay} file, you are now ready proceed with <<bootstrap>>.

--- a/adoc/deployment-loadbalancer.adoc
+++ b/adoc/deployment-loadbalancer.adoc
@@ -14,7 +14,7 @@ alternative server.
 
 This load balancer configuration is therefore only suitable for testing and proof-of-concept (POC) environments.
 
-For production environments, we recommend the use of link:https://www.suse.com/documentation/sle-ha-15/index.html[{sle} {hasi} 15]
+For production environments, we recommend the use of link:https://documentation.suse.com/sle-ha/15-SP1/[{sle} {hasi} 15]
 ====
 
 === Configuring the Load Balancer
@@ -166,7 +166,7 @@ The configuration of an HA cluster is out of the scope of this document.
 .Package Support
 [WARNING]
 ====
-`HAProxy` is available as a supported package with a link:https://www.suse.com/documentation/sle-ha-15/index.html[{sle} {hasi} 15] subscription.
+`HAProxy` is available as a supported package with a link:https://documentation.suse.com/sle-ha/15-SP1/[{sle} {hasi} 15] subscription.
 
 Alternatively, you can install `HAProxy` from link:https://packagehub.suse.com/packages/haproxy/[{pkghub}] but you will not receive product support for this component.
 ====


### PR DESCRIPTION
URL fix backports from 4.1, as 4.0 is currently still published as a supported product.
