### PR TITLE
Document addons customization

### DIFF
--- a/adoc/admin-security-ldap.adoc
+++ b/adoc/admin-security-ldap.adoc
@@ -253,7 +253,7 @@ Example LDIF configuration to create group `k8s-admins` using an LDAP command:
   memberUid: user-admin
 ====
 
-==== Example 2: Dex LDAP TLS Connector Configuration (`addons/dex/dex.yaml`)
+==== Example 2: Dex LDAP TLS Connector Configuration (`addons/dex/patches/custom.yaml`)
 Dex connector template configured to use 389-DS:
 ----
 connectors:
@@ -341,7 +341,7 @@ connectors:
       nameAttr: cn
 ----
 
-Then, refer to <<_sec.admin.security.rbac.update>> to apply the dex.yaml and <<_sec.admin.security.rbac.apply>> to access through Web or CLI.
+Then, refer to <<_sec.admin.security.rbac.update>> to apply the Dex custom.yaml and <<_sec.admin.security.rbac.apply>> to access through Web or CLI.
 
 === Active Directory
 

--- a/adoc/admin-security-psp.adoc
+++ b/adoc/admin-security-psp.adoc
@@ -52,7 +52,7 @@ and security.
 The policy definitions are embedded in the link:https://github.com/SUSE/skuba/blob/master/pkg/skuba/actions/cluster/init/manifests.go[cluster bootstrap manifest (GitHub)].
 
 During the bootstrap with `skuba`, the policy files will be stored on your
-workstation in the cluster definition folder under `addons/psp`. These policy files
+workstation in the cluster definition folder under `addons/psp/base`. These policy files
 will be installed automatically for all cluster nodes.
 
 The file names of the files created are:
@@ -65,7 +65,8 @@ and
 === Policy File Examples
 
 This is the unprivileged policy as a configuration file. You can use this
-as a basis to develop your own {psp}.
+as a basis to develop your own {psp} which should be saved as `custom-psp.yaml`
+`addons/psp/patches` drectory.
 
 ----
 apiVersion: policy/v1beta1

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -93,7 +93,9 @@ kubectl create rolebinding admin --clusterrole=admin --user=<USER_1> --user=<USE
 Administrators can update the authentication connector settings after {productname}
 deployment as follows:
 
-. Edit and save Dex addon YAML in `~/clusters/<CLUSTER_NAME>/addons/dex/dex.yml`
+. Base on the manifest in `~/clusters/<CLUSTER_NAME>/addons/dex/base/dex.yml` provide a kustomize patch to `~/clusters/<CLUSTER_NAME>/addons/dex/patches/custom.yml` of the form of strategic merge patch or a JSON 6902 patch.
+
+Read https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge and https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchjson6902 to get more information.
 +
 . Adapt ConfigMap by adding LDAP configuration to the connector section.
 For detailed configuration of the LDAP connector, refer to Dex documentation:
@@ -136,11 +138,6 @@ Besides the LDAP connector you can also set up other connectors.
 For additional connectors, refer to the available connector configurations in the Dex repository:
 https://github.com/dexidp/dex/tree/v2.16.0/Documentation/connectors.
 +
-. Apply changes:
-+
-----
-kubectl apply -f ~/clusters/<CLUSTER_NAME>/addons/dex/dex.yml
-----
 
 NOTE: Before any add-on upgrade, please backup any runtime configuration changes, then restore the modification back after upgraded. It is known limitation.
 

--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -464,29 +464,55 @@ structure like the following:
 ~/clusters > tree my-cluster/
 my-cluster/
 ├── addons
-│   ├── cni
-│   │   └── cilium.yaml
+│   ├── cilium
+│   │   ├── base
+│   │   │   └── cilium.yaml
+│   │   └── patches
 │   ├── cri
 │   │   └── default_flags
 │   ├── dex
-│   │   └── dex.yaml
+│   │   ├── base
+│   │   │   └── dex.yaml
+│   │   └── patches
 │   ├── gangway
-│   │   └── gangway.yaml
+│   │   ├── base
+│   │   │   └── gangway.yaml
+│   │   └── patches
 │   ├── kured
-│   │   └── kured.yaml
+│   │   ├── base
+│   │   │   └── kured.yaml
+│   │   └── patches
 │   └── psp
-│       ├── podsecuritypolicy-privileged.yaml
-│       └── podsecuritypolicy-unprivileged.yaml
+│       ├── base
+│       │   └── psp.yaml
+│       └── patches
 ├── kubeadm-init.conf
 └── kubeadm-join.conf.d
     ├── master.conf.template
     └── worker.conf.template
 
-8 directories, 10 files
+18 directories, 9 files
 ----
 
 At this point, you can inspect all generated files, and if desired you
-can experiment by changing the default settings.
+can experiment by providing your custom settings using with declarative 
+management of Kubernetes objects using Kustomize link:https://kustomize.io/
+
+To provide custom settings of the form of strategic merge patch or a JSON 6902 patch go to addons patches directory for example `addons/dex/pathes` and create custom settings file for example `addons/dex/pathes/custom.yaml`
+
+Read https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge and https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchjson6902 to get more information.
+
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oidc-dex
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 5
+----
+
 
 ==== Bootstrapping the first node of the cluster
 
@@ -505,7 +531,7 @@ Prior to bootstrap it's possible for you to tweak the configuration
 that will be used to create the cluster. You can:
 
 * Tweak the default Pod Security Policies or create extra ones. If you
-  place extra Pod Security Policies in the `addons/psp` folder, those
+  place extra Pod Security Policies in the `addons/psp/base` folder, those
   will be created as well when the bootstrap is completed. You can
   also modify the default ones and/or remove them.
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -284,8 +284,11 @@ You can use the "private dns" values provided by the {tf} output.
 
 ===== Integrate External LDAP TLS
 
-. Open the `Dex` `ConfigMap` in `my-cluster/addons/dex/dex.yaml`
-. Adapt the `ConfigMap` by adding LDAP configuration to the connector section of the `config.yaml` file. For detailed configurations for the LDAP connector, refer to https://github.com/dexidp/dex/blob/v2.16.0/Documentation/connectors/ldap.md.
+. Base on the manifest in `~/clusters/<CLUSTER_NAME>/addons/dex/base/dex.yml` provide a kustomize patch to `~/clusters/<CLUSTER_NAME>/addons/dex/patches/custom.yml` of the form of strategic merge patch or a JSON 6902 patch.
+. Adapt the `ConfigMap` by adding LDAP configuration to the connector section of the `custom.yaml` file. For detailed configurations for the LDAP connector, refer to https://github.com/dexidp/dex/blob/v2.16.0/Documentation/connectors/ldap.md.
+
+Read https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge and https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchjson6902 to get more information.
+
 ====
 # Example LDAP connector
 
@@ -333,7 +336,8 @@ it is possible to flag the pod with `--blocking-pod-selector=<POD_NAME>`.
 Any node running this workload will not be rebooted via `kured` and needs to
 be rebooted manually.
 
-. Open the `kured` deployment in `my-cluster/addons/kured/kured.yaml`
+. Base on the manifest in `~/clusters/<CLUSTER_NAME>/addons/kured/base/kured.yml` provide a kustomize patch to `~/clusters/<CLUSTER_NAME>/addons/kured/patches/custom.yml` of the form of strategic merge patch or a JSON 6902 patch.
+Read https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge and https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchjson6902 to get more information.
 . Adapt the `DaemonSet` by adding one of the following flags to the `command`
 section of the `kured` container:
 +
@@ -359,10 +363,10 @@ You can add any key/value labels to this selector:
 --blocking-pod-selector=<LABEL_KEY_1>=<LABEL_VALUE_1>,<LABEL_KEY_2>=<LABEL_VALUE_2>
 ----
 
-Alternatively you can adapt the `kured` DaemonSet also later during runtime (after bootstrap) by editing `my-cluster/addons/kured/kured.yaml` and executing:
+Alternatively you can adapt the `kured` DaemonSet also later during runtime (after bootstrap) by editing `my-cluster/addons/kured/patches/custom.yaml` and executing:
 [source,bash]
 ----
-kubectl apply -f my-cluster/addons/kured/kured.yaml
+kubectl apply -k my-cluster/addons/kured/
 ----
 
 This will restart all `kured` pods with the additional configuration flags.
@@ -375,7 +379,8 @@ By default, **any** prometheus alert blocks a node from reboot.
 However you can filter specific alerts to be ignored via the `--alert-filter-regexp` flag.
 ====
 
-. Open the `kured` deployment in `my-cluster/addons/kured/kured.yaml`
+. Base on the manifest in `~/clusters/<CLUSTER_NAME>/addons/kured/base/kured.yml` provide a kustomize patch to `~/clusters/<CLUSTER_NAME>/addons/kured/patches/custom.yml` of the form of strategic merge patch or a JSON 6902 patch.
+Read https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchstrategicmerge and https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md#patchjson6902 to get more information.
 . Adapt the `DaemonSet` by adding one of the following flags to the `command` section of the `kured` container:
 +
 ----
@@ -400,10 +405,10 @@ spec:
 The <PROMETHEUS_SERVER_URL> needs to contain the protocol (`http://` or `https://`)
 ====
 
-Alternatively you can adapt the `kured` DaemonSet also later during runtime (after bootstrap) by editing `my-cluster/addons/kured/kured.yaml` and executing:
+Alternatively you can adapt the `kured` DaemonSet also later during runtime (after bootstrap) by editing `my-cluster/addons/kured/patches/custom.yaml` and executing:
 [source,bash]
 ----
-kubectl apply -f my-cluster/addons/kured/kured.yaml
+kubectl apply -k my-cluster/addons/kured/
 ----
 
 This will restart all `kured` pods with the additional configuration flags.


### PR DESCRIPTION
# Change description 

After running `skuba cluster init`, this is the generated directory structure:

```
.
├── addons
│   ├── cilium
│   │   ├── base
│   │   │   └── cilium.yaml
│   │   └── patches
│   ├── cri
│   │   └── default_flags
│   ├── dex
│   │   ├── base
│   │   │   └── dex.yaml
│   │   └── patches
│   ├── gangway
│   │   ├── base
│   │   │   └── gangway.yaml
│   │   └── patches
│   ├── kured
│   │   ├── base
│   │   │   └── kured.yaml
│   │   └── patches
│   └── psp
│       ├── base
│       │   └── psp.yaml
│       └── patches
├── kubeadm-init.conf
└── kubeadm-join.conf.d
    ├── master.conf.template
    └── worker.conf.template

18 directories, 9 files
```

Every `base` manifest will contain a top explicit warning:

```
# Do not edit this file directly.
#
# Any manual changes made to this file will be ignored.
#
# If you want to adapt this addon manifest, use the "patches" directory,
# that allows you to provide strategic merge patches, and json 6902 patches
# (https://tools.ietf.org/html/rfc6902).
#
# More information: https://github.com/kubernetes-sigs/kustomize/blob/master/docs/glossary.md
```

This will instruct the user that any desired modifications should not
be done on the base manifests, but included as `*.yaml` or `*.json`
files inside the corresponding `patches` directory for each addon.

### `skuba addon upgrade apply`

When upgrading the addons, base manifests will forcefully re-rendered,
and patches present in the cluster definition folder will be applied
before the final manifests are submitted to the cluster.

### Patches

Any valid `kustomize` supported patch format is allowed inside the
`patches` directory for each addon, as long as it contains a `.yaml`
or `.json` extension, and is a valid patch of the formats:

* [Strategic merge patch (SMP)](https://github.com/kubernetes/community/blob/9e3689677b59cfcdebd83a9955ba90dda591c9b1/contributors/devel/sig-api-machinery/strategic-merge-patch.md)
* [JSON patch (RFC 6902)](https://tools.ietf.org/html/rfc6902)
* https://github.com/SUSE/caasp-rfc/blob/master/accepted/0046-addon-customizations.md

These patches present for each addon on its `patches` directory will
be applied unconditionally.

# Related Issues / Projects

https://github.com/SUSE/skuba/pull/858


# Labels
Please set any (and all) appropriate labels that describe the status of the PR.

| **Label** | **Description** |
| --- | --- |
| P1 | PR should be worked on and merged as soon as possible |
| Blocked | Work can not proceed because other work has not been completed, PR can not be merged (code has not been merged but documentation is ready) |
| On-Hold | Underlying work is completed but the PR should not be merged |
| ReleaseNotes | User interaction is required after the introduction of this change and the change must be mentioned in the release notes |
| v3/v4/v4.x | Which version of the release the PR should be merged into, this can be multiple versions, please set the "Backport" label if it needs to go into a previous release |
| Needs Review | Some details of the PR are known to be incomplete and must be discussed with other engineers before merging (if possible assign reviewers or cc mention in comments), PR can not be merged |
