### PR TITLE
Clarify certificate rotation process


### DIFF
--- a/adoc/admin-security-certificates.adoc
+++ b/adoc/admin-security-certificates.adoc
@@ -370,7 +370,7 @@ of logic than the control plane nodes: it runs `kubeadm upgrade node`
 which only restarts the kubelet on worker nodes.
 
 Kubelet configuration by default uses a `kubelet-client-current.pem` file, in
-its pki folder. This file is a symlink to the latest generated certificate.
+its `pki` folder. This file is a symlink to the latest generated certificate.
 Restarting the kubelet effectively rotates the certificate to read the latest
 generated file.
 

--- a/adoc/admin-security-certificates.adoc
+++ b/adoc/admin-security-certificates.adoc
@@ -355,6 +355,25 @@ kubectl delete pod -lapp=oidc-gangway -n kube-system
 It is a best practice to update your {kube} cluster frequently to stay secure.
 ====
 
+=== Control plane nodes certificates rotation
+
+When doing a control plane update, `skuba node upgrade apply` will run
+`kubeadm upgrade` commands behind the scenes. `kubeadm upgrade apply` and
+`kubeadm upgrade node` will renew and use new `kubeadm`
+managed certificates on the node, including those stored in kubeconfig files,
+regardless of the remaining time for which the certificate was still valid.
+
+=== Worker nodes certificates rotation
+
+Running `skuba node upgrade apply` on a worker node applies the same kind
+of logic than the control plane nodes: it runs `kubeadm upgrade node`
+which only restarts the kubelet on worker nodes.
+
+Kubelet configuration by default uses a `kubelet-client-current.pem` file, in
+its pki folder. This file is a symlink to the latest generated certificate.
+Restarting the kubelet effectively rotates the certificate to read the latest
+generated file.
+
 == Manual Certificate Renewal
 
 [IMPORTANT]

--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -380,8 +380,7 @@ Certificates are stored under `/etc/kubernetes/pki` on the control plane nodes.
 |etcd/peer.key                |RSA      |2048
 |===
 
-Please refer to the _{productname} Admin Guide_ for more information on
-the rotation of certificates.
+Please refer to the link:{docurl}single-html/caasp-admin/#_certificates[{productname} Administration Guide] for more information on the rotation of certificates.
 
 === Worker nodes certificates
 
@@ -437,8 +436,7 @@ Certificates are stored under `/var/lib/kubelet/pki` on the worker nodes.
 |kubelet.key |RSA      |2048
 |===
 
-Please refer to the _{productname} Admin Guide_ for more information on
-the rotation of certificates.
+Please refer to the link:{docurl}single-html/caasp-admin/#_certificates[{productname} Administration Guide] for more information on the rotation of certificates.
 
 === Cluster Management
 

--- a/adoc/architecture-description.adoc
+++ b/adoc/architecture-description.adoc
@@ -380,6 +380,9 @@ Certificates are stored under `/etc/kubernetes/pki` on the control plane nodes.
 |etcd/peer.key                |RSA      |2048
 |===
 
+Please refer to the _{productname} Admin Guide_ for more information on
+the rotation of certificates.
+
 === Worker nodes certificates
 
 The CA certificate for the cluster is stored under /etc/kubernetes/pki
@@ -433,6 +436,9 @@ Certificates are stored under `/var/lib/kubelet/pki` on the worker nodes.
 |Path        |Key type |Key length (bits)
 |kubelet.key |RSA      |2048
 |===
+
+Please refer to the _{productname} Admin Guide_ for more information on
+the rotation of certificates.
 
 === Cluster Management
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -429,7 +429,7 @@ Apply best practices for access control to this folder.
 During cluster bootstrap, {skuba} automatically generates a root CA certificate.
 You can however also deploy the {kube} cluster with your own custom root CA certificate.
 
-Please refer to the _{productname} Admin Guide_ for more information on custom certificates.
+Please refer to the link:{docurl}single-html/caasp-admin/#_certificates[{productname} Administration Guide] for more information on custom certificates.
 ====
 +
 [WARNING]


### PR DESCRIPTION


The explanation of the rotation of the certificates was a little bit terse.
This should clarify how rotation happens.

Closes: https://github.com/SUSE/doc-caasp/issues/714
Closes: https://github.com/SUSE/doc-caasp/issues/715

