### PR TITLE
Warning about multiples kubeconfig with the same user

### DIFF
--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -172,8 +172,24 @@ this can lead to issues, because only one of the machines will be able to refres
 The user will be able to download multiple kubeconfig files, but they will only work until one of them needs to refresh the session.
 After that, only one machine will work, namely the first machine which refreshed the token.
 
-One possible workaround for this issue is using multiple users for different kubeconfig
+*A workaround for this issue* is using multiple users for different kubeconfig
 files. See how to add more users in <<_sec.admin.security.users.add>>.
+You can also check information about the user and the respective OIDC tokens in the kubeconfig file under the `users` section:
+
+-----
+users:
+- name: myuser
+  user:
+    auth-provider:
+      config:
+        client-id: oidc
+        client-secret: <SECRET>
+        id-token:  <ID_TOKEN>
+        idp-issuer-url: https://<IP>:<PORT>
+        refresh-token: <REFRESH_TOKEN>
+      name: oidc
+-----
+
 
 ==== Access {kube} Resources
 

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -172,6 +172,8 @@ this can lead to issues, because only one of the machines will be able to refres
 The user will be able to download multiple kubeconfig files, but they will only work until one of them needs to refresh the session.
 After that, only one machine will work, namely the first machine which refreshed the token.
 
+One possible workaround for that is using multiple users for different kubeconfig
+files. Check how to add more users at <<_sec.admin.security.users.add>>
 
 ==== Access {kube} Resources
 

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -169,6 +169,18 @@ The user can now access resources in the authorized `<NAMESPACE>`.
 
 If the user has the proper permissions to access the resources, the output should look like this:
 
+[IMPORTANT]
+====
+The kubeconfig file downloaded by the user contains the OIDC tokens necessary to 
+perform authentication and authorization in the cluster. These tokens have an 
+expiration date which means that token needs to be refresh after some time. 
+If the customer uses the same user in multiples kubeconfig files distributed
+among many machines, this can be source of issues. Because just one of the machines 
+will be able to refresh the token. This means that the user will be able to download
+multiple kubeconfig files. But they will work until one of them need to refresh the session.
+After that, only one machine will work. The first machine which refreshed the token.
+====
+
 ----
 # kubectl -n <NAMESPACE> get pod
 

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -172,8 +172,8 @@ this can lead to issues, because only one of the machines will be able to refres
 The user will be able to download multiple kubeconfig files, but they will only work until one of them needs to refresh the session.
 After that, only one machine will work, namely the first machine which refreshed the token.
 
-One possible workaround for that is using multiple users for different kubeconfig
-files. Check how to add more users at <<_sec.admin.security.users.add>>
+One possible workaround for this issue is using multiple users for different kubeconfig
+files. See how to add more users in <<_sec.admin.security.users.add>>.
 
 ==== Access {kube} Resources
 

--- a/adoc/admin-security-rbac.adoc
+++ b/adoc/admin-security-rbac.adoc
@@ -163,23 +163,21 @@ NOTE: Before any add-on upgrade, please backup any runtime configuration changes
 login username and password.
 . The kubeconfig `kubeconf.txt` is generated locally.
 
+===== OIDC Tokens
+
+The kubeconfig file (`kubeconf.txt`) contains the OIDC tokens necessary to perform authentication and authorization in the cluster.
+OIDC tokens have an *expiration date* which means that they need to be refreshed after some time.
+If you use the *same user in multiples kubeconfig files* distributed among multiple machines,
+this can lead to issues, because only one of the machines will be able to refresh the token.
+The user will be able to download multiple kubeconfig files, but they will only work until one of them needs to refresh the session.
+After that, only one machine will work, namely the first machine which refreshed the token.
+
+
 ==== Access {kube} Resources
 
 The user can now access resources in the authorized `<NAMESPACE>`.
 
 If the user has the proper permissions to access the resources, the output should look like this:
-
-[IMPORTANT]
-====
-The kubeconfig file downloaded by the user contains the OIDC tokens necessary to 
-perform authentication and authorization in the cluster. These tokens have an 
-expiration date which means that token needs to be refresh after some time. 
-If the customer uses the same user in multiples kubeconfig files distributed
-among many machines, this can be source of issues. Because just one of the machines 
-will be able to refresh the token. This means that the user will be able to download
-multiple kubeconfig files. But they will work until one of them need to refresh the session.
-After that, only one machine will work. The first machine which refreshed the token.
-====
 
 ----
 # kubectl -n <NAMESPACE> get pod

--- a/adoc/admin-security-user-group-management.adoc
+++ b/adoc/admin-security-user-group-management.adoc
@@ -1,3 +1,5 @@
+[[_sec.admin.security.users]]
+
 = Managing Users and Groups
 
 You can use standard LDAP administration tools for managing organizations, groups and users remotely.
@@ -107,6 +109,7 @@ DS_DM_PASSWORD=                                 # Admin Password
 ldapmodify -v -H <LDAP_PROTOCOL>://<LDAP_NODE_FQDN><LDAP_NODE_PROTOCOL> -D "<BIND_DN>" -f <LDIF_FILE> -w <DS_DM_PASSWORD>
 ----
 
+[[_sec.admin.security.users.add]]
 === Adding a New User
 
 . To add a new user, create an LDIF file (`new_user.ldif`) like this:


### PR DESCRIPTION
Recently we have a customer trying to use multiples kubeconfig file with
the same user. This cause issue because after one of the machines with
the files refresh the OIDC token, the rest cannot refresh the token
anymore. This commit adds a warning about this situation.

Issue https://github.com/SUSE/doc-caasp/issues/735