### PR TITLE
Add vSphere cloud provider support document

### DIFF
--- a/adoc/admin-software-installation.adoc
+++ b/adoc/admin-software-installation.adoc
@@ -26,7 +26,7 @@ must be installed on the underlying operating system outside of {kube}.
 The following examples show installation of required packages for `Ceph`, please adjust the list of
 packages and repositories to whichever software you need to install.
 
-While you can install any software package from the {sles} ecosystem this falls outside of the support scope for {productname}.
+While you can install any software package from the {slsa} ecosystem this falls outside of the support scope for {productname}.
 ====
 
 === Initial Rollout

--- a/adoc/admin-storage-vsphere.adoc
+++ b/adoc/admin-storage-vsphere.adoc
@@ -1,0 +1,248 @@
+= vSphere Storage
+The vSphere cloud provider can be enabled with {productname} to allow Kubernetes pods to use VMWare vSphere Virtual Machine Disk (VMDK) volumes as persistent storage.
+
+This chapter provides the two types of persistent volume usage and description.
+
+== Node Meta
+Extra node meta could be found when region and zone was added to `vsphere.conf` before bootstrap cluster node.
+
+====
+    [Labels]
+    region = "<VC_DATACENTER_TAG>"
+    zone = "<VC_CLUSTER_TAG>"
+====
+
+You can view the cloudprovider associated node meta with command.
+----
+kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\tregion: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/region}{"\tzone: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}{"\n"}{end}'
+...
+010084072206    region: vcp-provo       zone: vcp-cluster-jazz
+010084073045    region: vcp-provo       zone: vcp-cluster-jazz
+----
+
+== Static Persistent Volume
+. Create new VMDK volume in datastore. The VMDK volume used in persistent volume must exist before the resource is created.
++
+You can use `govc` to automate the task. 
++
+Install intruction refer to https://github.com/vmware/govmomi/tree/master/govc.
++
+----
+govc datastore.disk.create -dc <DATA_CENTER> -ds <DATA_STORE> -size <DISK_SIZE> <DISK_NAME>
+----
+<DATA_CENTER> The datacenter name in vCenter where Kubernetes nodes reside.
++
+<DATA_STORE> The datastore in vCenter where volume should be created.
++
+<DISK_SIZE> The volume size to create, for example 1G.
++
+<DISK_NAME> The VMDK volume name. for example my-disk.vmdk, or my-cluster-folder/my-disk.vmdk.
+
+. Create persistent volume - sample-static-pv.yaml.
++
+----
+kubectl create -f sample-static-pv.yaml
+----
++
+====
+    apiVersion: v1
+    kind: PersistentVolume
+    metadata:
+      name: sample-static-pv // <1>
+    spec:
+      capacity:
+        storage: 1Gi // <2>
+      accessModes:
+      - ReadWriteOnce
+      persistentVolumeReclaimPolicy: Delete // <3>
+      vsphereVolume:
+        volumePath: "[datastore] volume/path" // <4>
+        fsType: ext4 // <5>
+====
+<1> The name of persistent volume resource.
+<2> The disk size available.
+<3> The policy for how persistent volume should be handled when it is released.
+<4> The path to VMDK volume. This path must exist.
+<5> The file system type to mount.
+
+. Create persistent volume claim - sample-static-pvc.yaml. 
++
+----
+kubectl create -f sample-static-pvc.yaml
+----
++
+====
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: sample-static-pvc
+      labels:
+        app: sample
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi // <1>
+====
+<1> The require volume size.
+
+. Create deployement - sample-static-deployment.yaml.
++
+----
+kubectl create -f sample-static-deployment.yaml
+----
++
+====
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: sample-static-deployment
+      labels:
+        app: sample
+        tier: sample
+    spec:
+      selector:
+        matchLabels:
+          app: sample
+          tier: sample
+      strategy:
+        type: Recreate
+      template:
+        metadata:
+          labels:
+            app: sample
+            tier: sample
+        spec:
+          containers:
+          - image: busybox
+            name: sample
+            volumeMounts:
+            - name: sample-volume
+              mountPath: /data // <1>
+            command: [ "sleep", "infinity" ]
+          volumes:
+          - name: sample-volume
+            persistentVolumeClaim:
+              claimName: sample-static-pvc // <2>
+====
++
+<1> The volume mount path in deployed pod.
+<2> The requested persistent volume claim name.
+
+. Check persistent volume claim is bonded and pod is running.
++
+----
+kubectl get pvc
+...
+NAME                STATUS   VOLUME             CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+sample-static-pvc   Bound    sample-static-pv   1Gi        RWO                           55s
+
+kubectl get pod
+...
+NAME                                        READY   STATUS    RESTARTS   AGE
+sample-static-deployment-549dc77d76-pwdqw   1/1     Running   0          3m42s
+----
+
+== Dynamic Persistent Volume
+
+. Create storage class - sample-sc.yaml.
++
+----
+kubectl create -f sample-sc.yaml
+----
++
+====
+    kind: StorageClass
+    apiVersion: storage.k8s.io/v1
+    metadata:
+      name: sample-sc
+      annotations:
+        storageclass.kubernetes.io/is-default-class: "true" // <1>
+    provisioner: kubernetes.io/vsphere-volume
+    parameters:
+      datastore: "datastore" // <2>
+====
+<1> Set as the default storage class.
+<2> The datastore name in vCenter where volume should be created.
+
+. Create persistent volume claim - sample-dynamic-pvc.yaml.
++
+----
+kubectl create -f sample-dynamic-pvc.yaml
+----
++
+====
+    apiVersion: v1
+    kind: PersistentVolumeClaim
+    metadata:
+      name: sample-dynamic-pvc
+      annotations:
+        volume.beta.kubernetes.io/storage-class: sample-sc // <1>
+      labels:
+        app: sample
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 1Gi // <2>
+====
+<1> Annotate with storage class name to use the storage class created. 
+<2> The require volume size.
+
+. Create deployment - sample-deployment.yaml
++
+----
+kubectl create -f sample-deployment.yaml
+----
++
+====
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: sample-dynamic-deployment
+    labels:
+      app: sample
+      tier: sample
+  spec:
+    selector:
+      matchLabels:
+        app: sample
+        tier: sample
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          app: sample
+          tier: sample
+      spec:
+        containers:
+        - image: busybox
+          name: sample
+          volumeMounts:
+          - name: sample-volume
+            mountPath: /data // <1>
+          command: [ "sleep", "infinity" ]
+        volumes:
+        - name: sample-volume
+          persistentVolumeClaim:
+            claimName: sample-dynamic-pvc // <2>
+====
+<1> The volume mount path in deployed pod
+<2> The requested persistent volume claim name
+
+. Check persistent volume claim is bonded and pod is running.
++
+----
+kubectl get pvc
+...
+NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+sample-dynamic-pvc   Bound    pvc-0ca694b5-0084-4e36-bef1-5b2354158d79   1Gi        RWO            sample-sc      70s
+
+kubectl get pod
+...
+NAME                                         READY   STATUS    RESTARTS   AGE
+sample-dynamic-deployment-687765d5b5-67vnh   1/1     Running   0          20s
+----

--- a/adoc/admin-storage-vsphere.adoc
+++ b/adoc/admin-storage-vsphere.adoc
@@ -3,9 +3,10 @@ The vSphere cloud provider can be enabled with {productname} to allow Kubernetes
 
 This chapter provides the two types of persistent volume usage and description.
 
-Please refer to <<cluster.bootstrap.vcp>> on how to setup vSphere cloud provider enabled cluster.
+Please refer to link:{docurl}single-html/caasp-deployment/#bootstrap[Cluster Bootstrap] on how to setup vSphere cloud provider enabled cluster.
 
 == Node Meta
+
 Extra node meta could be found when region and zone was added to `vsphere.conf` before bootstrap cluster node.
 
 ====
@@ -14,7 +15,10 @@ Extra node meta could be found when region and zone was added to `vsphere.conf` 
     zone = "<VC_CLUSTER_TAG>"
 ====
 
-Regions refers to the datacenter and zones refers to the cluster grouping of hosts within the datacenter. Adding region and zone makes Kubernetes persistent volume created with zone and region labels. With such environment, Kubernetes pod scheduler is set to be locational aware for the persistent volume. For more information refer to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html.
+`Region` refers to the datacenter and zones refers to the cluster grouping of hosts within the datacenter.
+Adding region and zone makes {kube} persistent volume created with zone and region labels.
+With such an environment, {kube} pod scheduler is set to be locational aware for the persistent volume.
+For more information refer to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html.
 
 You can view the cloudprovider associated node meta with command.
 ----
@@ -25,11 +29,12 @@ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\tregion: "}{.
 ----
 
 == Static Persistent Volume
+
 . Create new VMDK volume in datastore. The VMDK volume used in persistent volume must exist before the resource is created.
 +
-You can use `govc` to automate the task. 
+You can use `govc` to automate the task.
 +
-Install intruction refer to https://github.com/vmware/govmomi/tree/master/govc.
+For installation instructions, refer to: https://github.com/vmware/govmomi/tree/master/govc.
 +
 ----
 govc datastore.disk.create -dc <DATA_CENTER> -ds <DATA_STORE> -size <DISK_SIZE> <DISK_NAME>
@@ -69,7 +74,7 @@ kubectl create -f sample-static-pv.yaml
 <4> The path to VMDK volume. This path must exist.
 <5> The file system type to mount.
 
-. Create persistent volume claim - sample-static-pvc.yaml. 
+. Create persistent volume claim - sample-static-pvc.yaml.
 +
 ----
 kubectl create -f sample-static-pvc.yaml
@@ -89,7 +94,7 @@ kubectl create -f sample-static-pvc.yaml
         requests:
           storage: 1Gi // <1>
 ====
-<1> The require volume size.
+<1> The required volume size.
 
 . Create deployement - sample-static-deployment.yaml.
 +
@@ -192,8 +197,8 @@ kubectl create -f sample-dynamic-pvc.yaml
         requests:
           storage: 1Gi // <2>
 ====
-<1> Annotate with storage class name to use the storage class created. 
-<2> The require volume size.
+<1> Annotate with storage class name to use the storage class created.
+<2> The required volume size.
 
 . Create deployment - sample-deployment.yaml
 +
@@ -234,8 +239,8 @@ kubectl create -f sample-deployment.yaml
           persistentVolumeClaim:
             claimName: sample-dynamic-pvc // <2>
 ====
-<1> The volume mount path in deployed pod
-<2> The requested persistent volume claim name
+<1> The volume mount path in deployed pod.
+<2> The requested persistent volume claim name.
 
 . Check persistent volume claim is bonded and pod is running.
 +

--- a/adoc/admin-storage-vsphere.adoc
+++ b/adoc/admin-storage-vsphere.adoc
@@ -14,6 +14,8 @@ Extra node meta could be found when region and zone was added to `vsphere.conf` 
     zone = "<VC_CLUSTER_TAG>"
 ====
 
+Regions refers to the datacenter and zones refers to the cluster grouping of hosts within the datacenter. Adding region and zone makes Kubernetes persistent volume created with zone and region labels. With such environment, Kubernetes pod scheduler is set to be locational aware for the persistent volume. For more information refer to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html.
+
 You can view the cloudprovider associated node meta with command.
 ----
 kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\tregion: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/region}{"\tzone: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}{"\n"}{end}'

--- a/adoc/admin-storage-vsphere.adoc
+++ b/adoc/admin-storage-vsphere.adoc
@@ -3,6 +3,8 @@ The vSphere cloud provider can be enabled with {productname} to allow Kubernetes
 
 This chapter provides the two types of persistent volume usage and description.
 
+Please refer to <<cluster.bootstrap.vcp>> on how to setup vSphere cloud provider enabled cluster.
+
 == Node Meta
 Extra node meta could be found when region and zone was added to `vsphere.conf` before bootstrap cluster node.
 

--- a/adoc/admin-troubleshooting.adoc
+++ b/adoc/admin-troubleshooting.adoc
@@ -332,7 +332,7 @@ done
 
 == Debugging SLES Nodes provision
 
-If {tf} fails to setup the required {sles} infrastructure for your cluster, please provide the configuration
+If {tf} fails to setup the required {slsa} infrastructure for your cluster, please provide the configuration
 you applied in a form of a TAR archive.
 
 Create a `TAR` archive by compressing the {tf}.

--- a/adoc/book_admin.adoc
+++ b/adoc/book_admin.adoc
@@ -78,6 +78,10 @@ include::admin-stratos-web-console.adoc[Stratos Web Console, leveloffset=+2]
 
 include::admin-centralized-logging.adoc[leveloffset=+2]
 
+== Storage
+
+include::admin-storage-vsphere.adoc[leveloffset=+2]
+
 == Integration
 
 [NOTE]

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -333,6 +333,9 @@ Please remember to set proper file permissions for it, for example `600`.
     scsicontrollertype = pvscsi // <12>
     [Network]
     public-network = "VM Network" // <13>
+    [Labels] // <14>
+    region = "<VC_DATACENTER_TAG>" // <15>
+    zone = "<VC_CLUSTER_TAG>" // <16>
 ====
 <1> (required) Refers to the vCenter username for vSphere cloud provider to authenticate with.
 <2> (required) Refers to the vCenter password for vCenter user specified with `user`.
@@ -347,6 +350,12 @@ Please remember to set proper file permissions for it, for example `600`.
 <11> (required) The vCenter VM folder where Kubernetes nodes are in.
 <12> (required) Defines the SCSI controller in use on the VMs. Almost always set to `pvscsi`.
 <13> (optional) The network in vCenter where Kubernetes nodes should join. The default is "VM Network" if not specified.
+<14> (optional) The feature flag for zone and region support.
+[IMPORTANT]
+The zone and region tags must exist and assigned to datacenter and cluster before bootstrap. Instruction to tag zones and regions, reference to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html#tag-zones-and-regions-in-vcenter.
+
+<15> (optional) The category name of the tag assigned to the vCenter datacenter.
+<16> (optional) The category name of the tag assigned to the vCenter cluster.
 
 After setting options in the `vsphere.conf` file, please proceed with <<cluster.bootstrap>>.
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -362,8 +362,8 @@ After setting options in the `vsphere.conf` file, please proceed with <<cluster.
 
 [IMPORTANT]
 ====
-When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the same node names same as ~vSphere~ virtual machine's hostnames, as
-these names will be used by services to reconcile node metadata.
+When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the node names same as ~vSphere~ virtual machine's hostnames, as these names will be used by the `vSphere` cloud controller manager to reconcile node metadata.
+
 ====
 
 ===== Integrate External LDAP TLS

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -300,8 +300,8 @@ skuba cluster init --control-plane <LB_IP/FQDN> --cloud-provider vsphere my-clus
 ----
 
 Running the above command will create a directory `my-cluster/cloud/vsphere` with a
-`README.md` and an `vsphere.conf.template` in it. Copy `vsphere.conf.template`
-or create an `vsphere.conf` file inside `my-cluster/cloud/vsphere`,
+`README.md` and a `vsphere.conf.template` in it. Copy `vsphere.conf.template`
+or create a `vsphere.conf` file inside `my-cluster/cloud/vsphere`,
 according to the supported format.
 The supported format and content can be found in the official Kubernetes documentation:
 
@@ -319,29 +319,34 @@ Please remember to set proper file permissions for it, for example `600`.
     [Global]
     user = "<VC_ADMIN_USERNAME>" // <1>
     password = "<VC_ADMIN_PASSWORD>" // <2>
-    insecure-flag = "1" // <3>
-    [VirtualCenter <VC_IP_OR_FQDN>] // <4>
-    datacenters = "<VC_DATACENTERS>" // <5>
+    port = "443" // <3>
+    insecure-flag = "1" // <4>
+    [VirtualCenter <VC_IP_OR_FQDN>] // <5>
+    datacenters = "<VC_DATACENTERS>" // <6>
     [Workspace]
-    server = "<VC_IP_OR_FQDN>" // <6>
-    datacenter = "<VC_DATACENTER>" // <7>
-    default-datastore = "<VC_DATASTORE>" // <8>
-    resourcepool-path = "<VC_RESOURCEPOOL_PATH>" // <9>
-    folder = "<VC_VM_FOLDER>" // <10>
+    server = "<VC_IP_OR_FQDN>" // <7>
+    datacenter = "<VC_DATACENTER>" // <8>
+    default-datastore = "<VC_DATASTORE>" // <9>
+    resourcepool-path = "<VC_RESOURCEPOOL_PATH>" // <10>
+    folder = "<VC_VM_FOLDER>" // <11>
     [Disk]
-    scsicontrollertype = pvscsi // <11>
+    scsicontrollertype = pvscsi // <12>
+    [Network]
+    public-network = "VM Network" // <13>
 ====
 <1> (required) Refers to the vCenter username for vSphere cloud provider to authenticate with.
-<2> (required) Refers to the vCenter password for vCenter user spcecified with `user`.
-<3> (optional) Set to 1 if vCenter used a self-signed certificate.
-<4> (required) The IP address of the vCenter server.
-<5> (required) The datacenter name in vCenter where Kubernetes nodes reside.
-<6> (required) The IP address of the vCenter server for storage provisioning. Usually the same as `VirtualCenter`
-<7> (required) The datacenter to provision temporary VMs for volume provisioning.
-<8> (required) The default datastore to provision temporary VMs for volume provisioning.
-<9> (required) The resource pool to provision temporary VMs for volume provisioning.
-<10> (required) The vCenter VM folder where Kubernetes nodes are in.
-<11> (required) Defines the SCSI controller in use on the VMs. Almost always set to `pvscsi`.
+<2> (required) Refers to the vCenter password for vCenter user specified with `user`.
+<3> (optional) The vCenter Server Port. The default is 443 if not specified.
+<4> (optional) Set to 1 if vCenter used a self-signed certificate.
+<5> (required) The IP address of the vCenter server.
+<6> (required) The datacenter name in vCenter where Kubernetes nodes reside.
+<7> (required) The IP address of the vCenter server for storage provisioning. Usually the same as `VirtualCenter`
+<8> (required) The datacenter to provision temporary VMs for volume provisioning.
+<9> (required) The default datastore to provision temporary VMs for volume provisioning.
+<10> (required) The resource pool to provision temporary VMs for volume provisioning.
+<11> (required) The vCenter VM folder where Kubernetes nodes are in.
+<12> (required) Defines the SCSI controller in use on the VMs. Almost always set to `pvscsi`.
+<13> (optional) The network in vCenter where Kubernetes nodes should join. The default is "VM Network" if not specified.
 
 After setting options in the `vsphere.conf` file, please proceed with <<cluster.bootstrap>>.
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -302,11 +302,9 @@ skuba cluster init --control-plane <LB_IP/FQDN> --cloud-provider vsphere my-clus
 
 Running the above command will create a directory `my-cluster/cloud/vsphere` with a
 `README.md` and a `vsphere.conf.template` in it. Copy `vsphere.conf.template`
-or create a `vsphere.conf` file inside `my-cluster/cloud/vsphere`,
-according to the supported format.
-The supported format and content can be found in the official Kubernetes documentation:
+or create a `vsphere.conf` file inside `my-cluster/cloud/vsphere`, according to the supported format.
 
-link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#vsphere[official Kubernetes documentation].
+The supported format and content can be found in the link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#vsphere[official Kubernetes documentation].
 
 [WARNING]
 ====
@@ -353,7 +351,8 @@ Please remember to set proper file permissions for it, for example `600`.
 <13> (optional) The network in vCenter where Kubernetes nodes should join. The default is "VM Network" if not specified.
 <14> (optional) The feature flag for zone and region support.
 [IMPORTANT]
-The zone and region tags must exist and assigned to datacenter and cluster before bootstrap. Instruction to tag zones and regions, reference to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html#tag-zones-and-regions-in-vcenter.
+The zone and region tags must exist and assigned to datacenter and cluster before bootstrap.
+Instruction to tag zones and regions, refer to: https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/zones.html#tag-zones-and-regions-in-vcenter.
 
 <15> (optional) The category name of the tag assigned to the vCenter datacenter.
 <16> (optional) The category name of the tag assigned to the vCenter cluster.
@@ -362,8 +361,8 @@ After setting options in the `vsphere.conf` file, please proceed with <<cluster.
 
 [IMPORTANT]
 ====
-When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the node names same as ~vSphere~ virtual machine's hostnames, as these names will be used by the `vSphere` cloud controller manager to reconcile node metadata.
-
+When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the node names same as ~vSphere~ virtual machine's hostnames.
+These names will be used by the `vSphere` cloud controller manager to reconcile node metadata.
 ====
 
 ===== Integrate External LDAP TLS

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -160,7 +160,7 @@ and Storage services.
 
 If you want to enable cloud provider integration with different cloud platforms,
 initialize the cluster with the flag `--cloud-provider <CLOUD PROVIDER>`.
-The only currently available options are `openstack` and `aws`,
+The only currently available options are `openstack`, `aws` and `vsphere`,
 but more options are planned.
 
 .Cleanup
@@ -290,6 +290,66 @@ these names will be used by the `AWS` cloud controller manager to reconcile node
 You can use the "private dns" values provided by the {tf} output.
 ====
 
+====== vSphere In-tree CPI (VCP)
+
+Define the cluster using the following command:
+
+[source,bash]
+----
+skuba cluster init --control-plane <LB_IP/FQDN> --cloud-provider vsphere my-cluster
+----
+
+Running the above command will create a directory `my-cluster/cloud/vsphere` with a
+`README.md` and an `vsphere.conf.template` in it. Copy `vsphere.conf.template`
+or create an `vsphere.conf` file inside `my-cluster/cloud/vsphere`,
+according to the supported format.
+The supported format and content can be found in the official Kubernetes documentation:
+
+link:https://kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#vsphere[official Kubernetes documentation].
+
+[WARNING]
+====
+The file `my-cluster/cloud/vsphere/vsphere.conf` must not be freely accessible.
+Please remember to set proper file permissions for it, for example `600`.
+====
+
+===== Example vSphere Cloud Provider Configuration
+
+====
+    [Global]
+    user = "<VC_ADMIN_USERNAME>" // <1>
+    password = "<VC_ADMIN_PASSWORD>" // <2>
+    insecure-flag = "1" // <3>
+    [VirtualCenter <VC_IP_OR_FQDN>] // <4>
+    datacenters = "<VC_DATACENTERS>" // <5>
+    [Workspace]
+    server = "<VC_IP_OR_FQDN>" // <6>
+    datacenter = "<VC_DATACENTER>" // <7>
+    default-datastore = "<VC_DATASTORE>" // <8>
+    resourcepool-path = "<VC_RESOURCEPOOL_PATH>" // <9>
+    folder = "<VC_VM_FOLDER>" // <10>
+    [Disk]
+    scsicontrollertype = pvscsi // <11>
+====
+<1> (required) Refers to the vCenter username for vSphere cloud provider to authenticate with.
+<2> (required) Refers to the vCenter password for vCenter user spcecified with `user`.
+<3> (optional) Set to 1 if vCenter used a self-signed certificate.
+<4> (required) The IP address of the vCenter server.
+<5> (required) The datacenter name in vCenter where Kubernetes nodes reside.
+<6> (required) The IP address of the vCenter server for storage provisioning. Usually the same as `VirtualCenter`
+<7> (required) The datacenter to provision temporary VMs for volume provisioning.
+<8> (required) The default datastore to provision temporary VMs for volume provisioning.
+<9> (required) The resource pool to provision temporary VMs for volume provisioning.
+<10> (required) The vCenter VM folder where Kubernetes nodes are in.
+<11> (required) Defines the SCSI controller in use on the VMs. Almost always set to `pvscsi`.
+
+After setting options in the `vsphere.conf` file, please proceed with <<cluster.bootstrap>>.
+
+[IMPORTANT]
+====
+When cloud provider integration is enabled, it's very important to bootstrap and join nodes with the same node names same as ~vSphere~ virtual machine's hostnames, as
+these names will be used by services to reconcile node metadata.
+====
 
 ===== Integrate External LDAP TLS
 

--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -290,6 +290,7 @@ these names will be used by the `AWS` cloud controller manager to reconcile node
 You can use the "private dns" values provided by the {tf} output.
 ====
 
+[[cluster.bootstrap.vcp]]
 ====== vSphere In-tree CPI (VCP)
 
 Define the cluster using the following command:

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -290,6 +290,13 @@ caasp_registry_code = "CAASP_REGISTRATION_CODE"
 +
 This is required so all the deployed nodes can automatically register with {scc} and retrieve packages.
 
+. You can also enable Cloud Provider Integration with vSphere.
++
+----
+# Enable CPI integration with vSphere
+cpi_enable = true
+----
+
 Once the files are adjusted, `terraform` needs to know about the `vSphere` server
 and the login details for it; these can be exported as environment variables or
 entered every time `terraform` is invoked.

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -297,8 +297,7 @@ This is required so all the deployed nodes can automatically register with {scc}
 cpi_enable = true
 ----
 
-. You can also disable node hostnames set from DHCP server. It is recommended when you enabled CPI integration
-with vSphere. This sets ~vSphere~ virtual machine's hostnames to match node names.
+. You can also disable node hostnames set from DHCP server. It is recommended when you enabled CPI integration with vSphere. This sets ~vSphere~ virtual machine's hostname with a naming convention (`"<stack_name>-master-<index>"` or `"<stack_name>-worker-<index>"`). This can be used as node name when using `skuba` command to bootstrapping or joining nodes. It is manatory that each virtual machine's hostname must match its cluster node name.
 +
 ----
 # Set node's hostname from DHCP server

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -297,7 +297,12 @@ This is required so all the deployed nodes can automatically register with {scc}
 cpi_enable = true
 ----
 
-. You can also disable node hostnames set from DHCP server. It is recommended when you enabled CPI integration with vSphere. This sets ~vSphere~ virtual machine's hostname with a naming convention (`"<stack_name>-master-<index>"` or `"<stack_name>-worker-<index>"`). This can be used as node name when using `skuba` command to bootstrapping or joining nodes. It is manatory that each virtual machine's hostname must match its cluster node name.
+. You can also disable node hostnames set from DHCP server. It is recommended when you enabled CPI integration with vSphere. This sets ~vSphere~ virtual machine's hostname with a naming convention (`"<stack_name>-master-<index>"` or `"<stack_name>-worker-<index>"`). This can be used as node name when using `skuba` command to bootstrapping or joining nodes.
++
+[IMPORTANT]
+====
+It is mandatory that each virtual machine's hostname must match its cluster node name.
+====
 +
 ----
 # Set node's hostname from DHCP server

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -297,6 +297,14 @@ This is required so all the deployed nodes can automatically register with {scc}
 cpi_enable = true
 ----
 
+. You can also disable node hostnames set from DHCP server. It is recommended when you enabled CPI integration
+with vSphere. This sets ~vSphere~ virtual machine's hostnames to match node names.
++
+----
+# Set node's hostname from DHCP server
+hostname_from_dhcp = false
+----
+
 Once the files are adjusted, `terraform` needs to know about the `vSphere` server
 and the login details for it; these can be exported as environment variables or
 entered every time `terraform` is invoked.


### PR DESCRIPTION
# Make sure it's tested
```
skuba-cluster ➤ kubectl get nodes -o jsonpath='{range .items[*]}{.metadata.name}{"\tregion: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/region}{"\tzone: "}{.metadata.labels.failure-domain\.beta\.kubernetes\.io/zone}{"\n"}{end}'
010084072206    region: vcp-provo       zone: vcp-cluster-jazz
010084073045    region: vcp-provo       zone: vcp-cluster-jazz
 
skuba-cluster ➤ kubectl get pvc                                                                         
NAME                 STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
sample-dynamic-pvc   Bound    pvc-0ca694b5-0084-4e36-bef1-5b2354158d79   1Gi        RWO            sample-sc      9m31s
sample-static-pvc    Bound    pvc-132cc94c-6f4e-4de9-a63e-4ed1b27cc33a   1Gi        RWO            sample-sc      50s

skuba-cluster ➤ kubectl get pod                                                                         
NAME                                         READY   STATUS    RESTARTS   AGE                           
sample-dynamic-deployment-687765d5b5-67vnh   1/1     Running   0          9m24s                         
sample-static-deployment-9f549f88b-vwssd     1/1     Running   0          34s  
```

# Describe your changes
The skuba added support for in-tree vSphere Cloud Provider.

# Related Issues / Projects
Relates to: https://github.com/SUSE/avant-garde/issues/1487

# Enable maintainer updates
Please enable maintainer updates so we can push commits into your branch to make collaboration and reviews easier.

# Do not force push your branch
Please avoid force pushing to branches that are subject of pull requests. Force pushing breaks maintainer commits in many cases and is very hard (if not impossible) to untangle for backporting.

# Labels
Please set any (and all) appropriate labels that describe the status of the PR.

| **Label** | **Description** |
| --- | --- |
| P1 | PR should be worked on and merged as soon as possible |
| Blocked | Work can not proceed because other work has not been completed, PR can not be merged (code has not been merged but documentation is ready) |
| On-Hold | Underlying work is completed but the PR should not be merged |
| ReleaseNotes | User interaction is required after the introduction of this change and the change must be mentioned in the release notes |
| v3/v4/v4.x | Which version of the release the PR should be merged into, this can be multiple versions, please set the "Backport" label if it needs to go into a previous release |
| Needs Review | Some details of the PR are known to be incomplete and must be discussed with other engineers before merging (if possible assign reviewers or cc mention in comments), PR can not be merged |

Signed-off-by: Chin-Ya Huang <chin-ya.huang@suse.com>