### PR TITLE
Warning about rsyslog running on machine and cluster

### DIFF
--- a/adoc/admin-centralized-logging.adoc
+++ b/adoc/admin-centralized-logging.adoc
@@ -41,7 +41,6 @@ OS Components::
 
 Centralized Logging is also restricted to the following protocols: UDP, TCP, TCP + TLS, TCP + mTLS.
 
-
 == Log Formats
 
 The two supported syslog message formats are *RFC 5424* and *RFC 3164*.
@@ -88,17 +87,17 @@ helm install suse/log-agent-rsyslog --name ${RELEASE_NAME} --namespace kube-syst
 ====
 If not specified otherwise, Helm will install log agents with TCP as the default value for `server.protocol`.
 ====
+
 [WARNING]
 ====
-Running Rsyslog in the host machine as well as in the Kubernetes cluster with imjournal and imfile input modules enabled may causes issues. Rsyslog can crash.
-To avoid that, it is possible to disable the imjournal module in the helm chart installation adding the following command line argument:
+Running Rsyslog in the host machine as well as in the {kube} cluster with `imjournal` and `imfile` input modules enabled may causes issues. Rsyslog can crash.
+To avoid that, it is possible to disable the `imjournal` module in the helm chart installation adding the following command line argument:
 
 [source,bash]
 ----
 --set logs.osSystem.enabled=false
 ----
 ====
-
 
 After this step, all of the log agents will initialize then start to forward logs from each node to the configured remote Rsyslog server.
 

--- a/adoc/admin-centralized-logging.adoc
+++ b/adoc/admin-centralized-logging.adoc
@@ -88,6 +88,16 @@ helm install suse/log-agent-rsyslog --name ${RELEASE_NAME} --namespace kube-syst
 ====
 If not specified otherwise, Helm will install log agents with TCP as the default value for `server.protocol`.
 ====
+[WARNING]
+====
+Running Rsyslog in the host machine as well as in the Kubernetes cluster with imjournal and imfile input modules enabled may causes issues. Rsyslog can crash.
+To avoid that, it is possible to disable the imjournal module in the helm chart installation adding the following command line argument:
+
+[source,bash]
+----
+--set logs.osSystem.enabled=false
+----
+====
 
 
 After this step, all of the log agents will initialize then start to forward logs from each node to the configured remote Rsyslog server.


### PR DESCRIPTION
Adds a simple warning message notifying the user of a possible issue
when imjournal and imfile modules are enabled in Rsyslog running on the
host machine and containers in the Kubernetes cluster.

Related to the bsc#1155969

Signed-off-by: José Guilherme Vanz <jguilhermevanz@suse.com>
