### PR TITLE
adoc: added list of changes from kubernetes 1.17. to 1.18

### DIFF
--- a/adoc/admin-kubernetes-changes.adoc
+++ b/adoc/admin-kubernetes-changes.adoc
@@ -1,0 +1,68 @@
+== From Kubernetes 1.17 to 1.18
+
+This documentation page lists all the behavioral changes and API deprecations that will happen from Kubernetes 1.17 to 1.18. This is going to be relevant when migrating to {productname} 4.3.x, since it will bring Kubernetes 1.18.
+
+=== API deprecations
+
+The following APIs have been deprecated:
+
+- All resources under *apps/v1beta1* and *apps/v1beta2*: please use *apps/v1* instead.
+- *daemonsets*, *deployments*, *replicasets* under *extensions/v1beta1*: please use *apps/v1* instead.
+- *networkpolicies* under *extensions/v1beta1*: please use *networking.k8s.io/v1* instead.
+- *podsecuritypolicies* resources under *extensions/v1beta1*: please use *policy/v1beta1* instead.
+
+=== Behavioral changes
+
+In this section we will highlight some relevant changes that might interest you for the new Kubernetes version.
+
+==== Core
+
+- link:https://github.com/kubernetes/enhancements/issues/853[#853] Configurable scale velocity for HPA.
+- link:https://github.com/kubernetes/enhancements/issues/1393[#1393] Provide OIDC discovery for service account token issuer.
+- link:https://github.com/kubernetes/enhancements/issues/1513[#1513] CertificateSigningRequest API.
+
+==== Scheduling
+
+- link:https://github.com/kubernetes/enhancements/issues/1451[#1451] Run multiple Scheduling Profiles [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/895[#895] Even pod spreading across failure domains [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/1258[#1258] Add a configurable default Even Pod Spreading rule [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/166[#166] Taint Based Eviction [Stable]
+
+==== Nodes
+
+- link:https://github.com/kubernetes/enhancements/issues/1539[#1539] Extending Hugepage Feature [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/688[#688] Pod Overhead: account resources tied to the pod sandbox, but not specific containers [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/693[#693] Node Topology Manager [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/950[#950] Add pod-startup liveness-probe holdoff for slow-starting pods [Beta]
+
+==== Networking
+
+- link:https://github.com/kubernetes/enhancements/issues/752[#752] EndpointSlice API [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/508[#508] IPv6 support added [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/1024[#1024] Graduate NodeLocal DNSCache to GA [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/1453[#1453] Graduate Ingress to V1 [Beta]
+- link:https://github.com/kubernetes/enhancements/issues/1507[#1507] Adding AppProtocol to Services and Endpoints [Stable]
+
+==== API
+
+- link:https://github.com/kubernetes/enhancements/issues/1040[#1040] Priority and Fairness for API Server Requests [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/1601[#1601] client-go signature refactor to standardize options and context handling [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/576[#576] APIServer DryRun [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/1281[#1281] API Server Network Proxy KEP to Beta [Beta]
+
+==== Storage
+
+- link:https://github.com/kubernetes/enhancements/issues/695[#695] Skip Volume Ownership Change [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/1412[#1412] Immutable Secrets and ConfigMaps [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/1495[#1495] Generic data populators [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/770[#770] Skip attach for non-attachable CSI volumes [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/351[#351] Raw block device using persistent volume source [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/565[#565] CSI Block storage support [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/603[#603] Pass Pod information in CSI calls [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/989[#989] Extend allowed PVC DataSources [Stable]
+
+==== Features
+
+- link:https://github.com/kubernetes/enhancements/issues/1441[#1441] kubectl debug [Alpha]
+- link:https://github.com/kubernetes/enhancements/issues/491[#491] kubectl diff [Stable]
+- link:https://github.com/kubernetes/enhancements/issues/670[#670] Support Out-of-Tree vSphere Cloud Provider [Stable]

--- a/adoc/admin-kubernetes-changes.adoc
+++ b/adoc/admin-kubernetes-changes.adoc
@@ -1,6 +1,7 @@
 == From Kubernetes 1.17 to 1.18
 
-This documentation page lists all the behavioral changes and API deprecations that will happen from Kubernetes 1.17 to 1.18. This is going to be relevant when migrating to {productname} 4.3.x, since it will bring Kubernetes 1.18.
+This documentation page lists all the behavioral changes and API deprecations that will happen from {kube} 1.17 to 1.18. 
+You will require this information when migrating to {productname} 5.x shipping with {kube} 1.18.
 
 === API deprecations
 
@@ -13,7 +14,7 @@ The following APIs have been deprecated:
 
 === Behavioral changes
 
-In this section we will highlight some relevant changes that might interest you for the new Kubernetes version.
+In this section we will highlight some relevant changes that might interest you for the new {kube} version.
 
 ==== Core
 

--- a/adoc/book_admin.adoc
+++ b/adoc/book_admin.adoc
@@ -107,6 +107,8 @@ include::admin-crio-registries.adoc[CRI-O Registry Configuration,leveloffset=+1]
 //include::admin-security-rbac.adoc[Role Based Access Control (RBAC),leveloffset=+1]
 include::admin-flexvolume.adoc[Flexvolume Configuration, leveloffset=+2]
 
+include::admin-kubernetes-changes.adoc[Kubernetes changes from 1.17 to 1.18,leveloffset=+1]
+
 == Troubleshooting
 
 include::admin-troubleshooting.adoc[Troubleshooting,leveloffset=+1]


### PR DESCRIPTION
I've added a new miscellanous page in which we document changes from 1.17 to 1.18 that might be relevant to our customers (e.g. API changes or some behavioral changes).

# Describe your changes

I've added into a new page the changes from Kubernetes 1.17 to 1.18. As for the behavioral changes, I've kept things simple, instead of writing larger descriptions as I initially intended (since it was becoming tedious to read and not that useful for customers in the end).

The changes described here are based on a presentation delivered by @mjura internally.

# Related Issues / Projects

Fixes SUSE/avant-garde#1420

I've decided not to base this PR from #756 since I'm not sure whether all the versions changed there are definitive.
