### PR TITLE
Remove reference to crio.conf


### DIFF
--- a/adoc/admin-troubleshooting.adoc
+++ b/adoc/admin-troubleshooting.adoc
@@ -317,8 +317,6 @@ journalctl -u crio
 
 # a copy of /etc/sysconfig/crio
 
-# a copy of /etc/crio/crio.conf
-
 # a copy of every file under /etc/crio/
 
 # Run the following three commands for every container using this loop:


### PR DESCRIPTION

Starting with crio 1.18, crio.conf will be moved towards
a crio.conf.d folder. All references to crio.conf should be
removed from 4.3.0 docs.

Related: https://github.com/SUSE/avant-garde/issues/1420

