### PR TITLE
Fix airgapped mirror docs


### DIFF
--- a/adoc/deployment-airgapped.adoc
+++ b/adoc/deployment-airgapped.adoc
@@ -396,7 +396,11 @@ CATEGORY:IMAGE:URL
 KUBEADM:hyperkube:registry.suse.com/caasp/v4/hyperkube
 KUBEADM:pause:registry.suse.com/caasp/v4/pause
 KUBEADM:coredns:registry.suse.com/caasp/v4/coredns
-KUBEADM:etcd:egistry.suse.com/caasp/v4/etcd
+KUBEADM:etcd:registry.suse.com/caasp/v4/etcd
+KUBEADM:api-server:registry.suse.com/caasp/v4/api-server
+KUBEADM:controller-manager:registry.suse.com/caasp/v4/controller-manager
+KUBEADM:scheduler:registry.suse.com/caasp/v4/scheduler
+KUBEADM:proxy:registry.suse.com/caasp/v4/proxy
 ADDONS:cilium:registry.suse.com/caasp/v4/cilium-init
 ADDONS:cilium:registry.suse.com/caasp/v4/cilium-operator
 ADDONS:cilium:registry.suse.com/caasp/v4/cilium


### PR DESCRIPTION


This image slipped through the cracks. Hyperkube needs to be mirrored
for old clusters or clusters currently migrating, and starting
with 4.3.0, the image won't be necessary anymore.

This should help on the airgapped story.

Related: https://github.com/SUSE/avant-garde/issues/1420

