### PR TITLE
Fix numbered list and indentation

### DIFF
--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -291,14 +291,14 @@ caasp_registry_code = "CAASP_REGISTRATION_CODE"
 ----
 +
 This is required so all the deployed nodes can automatically register with {scc} and retrieve packages.
-
-Once the files are adjusted, `terraform` needs to know about the `vSphere` server
++
+. Once the files are adjusted, `terraform` needs to know about the `vSphere` server
 and the login details for it; these can be exported as environment variables or
 entered every time `terraform` is invoked.
-
-Additionally, the `ssh-key` that is specified in the `tfvars` file must be added
++
+. Additionally, the `ssh-key` that is specified in the `tfvars` file must be added
 to the keyring, so the machine running `skuba` can `ssh` into the machines:
-
++
 ----
 export VSPHERE_SERVER="<server_address"
 export VSPHERE_USER="<username>"
@@ -307,9 +307,9 @@ export VSPHERE_ALLOW_UNVERIFIED_SSL=true # In case you are using custom certific
 
 ssh-add <path_to_private_ssh_key_from_tfvars>
 ----
-
-Run Terraform to create the required machines for use with `skuba`:
-
++
+. Run Terraform to create the required machines for use with `skuba`:
++
 ----
 terraform init
 terraform plan

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -278,6 +278,8 @@ mv terraform.tfvars.example terraform.tfvars
 . Edit the `terraform.tfvars` file and add/modify the following variables:
 +
 include::deployment-terraform-example.adoc[tag=tf_vmware]
+
+[start=4]
 . Enter the registration code for your nodes in `~/caasp/deployment/vmware/registration.auto.tfvars`:
 +
 Substitute `<CAASP_REGISTRATION_CODE>` for the code from <<registration_code>>.


### PR DESCRIPTION
Found one issue with numbered list (should be solved by `[start=4]`) and indentation (should be solved by a newline) when after using `include::<file>` the list numbering is reset.

I didn't try to generate any output so it's untested - I just tried adoc WYSIWYG preview in vscode.