### PR TITLE
Add <productname>/<productnumber> tags

### DIFF
--- a/adoc/docinfo.xml
+++ b/adoc/docinfo.xml
@@ -6,3 +6,6 @@
    <dm:editurl>https://github.com/SUSE/doc-caasp/edit/master/adoc/</dm:editurl>
    <dm:translation>yes</dm:translation>
 </dm:docmanager>
+
+<productname>SUSE CaaS Platform</productname>
+<productnumber>5.0.0</productnumber>


### PR DESCRIPTION
Without productname/productnumber tags, most HTML output files won't have a good on-page
indication what version of CaaSP is documented.

If you agree to this, backport to 4.x might be helpful.