### PR TITLE
Update admission controller info in GPU guide

### DIFF
--- a/adoc/admin-gpus.adoc
+++ b/adoc/admin-gpus.adoc
@@ -86,41 +86,22 @@ In a heterogeneous cluster, it may be preferable to prevent scheduling pods that
 
 [source,bash]
 ----
-$ kubectl taint nodes worker0 nvidia.com/gpu=:NoSchedule
+$ kubectl taint nodes worker0 nvidia.com/gpu=:PreferNoSchedule
 ----
 
 or
 
 [source,bash]
 ----
-$ kubectl taint nodes worker0 nvidia.com/gpu=:PreferNoSchedule
+$ kubectl taint nodes worker0 nvidia.com/gpu=:NoSchedule
 ----
 
-See the Kubernetes documentation on link:{kubedoc}concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] for a discussion on the considerations for using the NoSchedule or PreferNoSchedule effects.
+See the Kubernetes documentation on link:{kubedoc}concepts/scheduling-eviction/taint-and-toleration/[taints and tolerations] for a discussion on the considerations for using the NoSchedule or PreferNoSchedule effects. If you use the NoSchedule effect, you must also add the appropriate toleration to infrastructure-critical Daemonsets that must run on all nodes, such as the kured, kube-proxy, and cilium Daemonsets.
 
-The link:{kubedoc}reference/access-authn-authz/admission-controllers/#extendedresourcetoleration[ExtendedResourceToleration admission controller] will automatically add the nvidia.com/gpu toleration to pods that request the nvidia.com/gpu resource, so you will not need to add this toleration explicitly for every GPU workload. When after initializing the cluster but before bootstrapping it, add the ExtendedResourceToleration to the list of enabled admission plugins in your cluster's kubeadm-init.conf file:
-
-```
-$ sed -i -e '/enable-admission-plugins:/ s/$/,ExtendedResourceToleration/' kubeadm-init.conf
-```
-
-Then begin the cluster bootstrapping process as described in link:{docurl}/single-html/caasp-admin/#_cluster_management[Cluster Management].
-
-If you are enabling GPU support in an existing cluster, you can add the admission controller to the API server configuration on every master node:
-
-[source,bash]
-----
-# sed -i -e '/--enable-admission-plugins=/ s/$/,ExtendedResourceToleration/' /etc/kubernetes/manifests/kube-apiserver.yaml
-----
-
-Wait for the kube-apiserver pod to be restarted.
-
-In order to ensure this change persists across upgrades, add the admission plugin to the kubeadm configmap:
-
-[source,bash]
-----
-$ kubectl --namespace kube-system get configmap kubeadm-config -o yaml | sed -e '/enable-admission-plugins:/ s/$/,ExtendedResourceToleration/' | kubectl apply -f -
-----
+[NOTE]
+====
+The link:{kubedoc}reference/access-authn-authz/admission-controllers/#extendedresourcetoleration[ExtendedResourceToleration admission controller] is enabled on {productname} v5 by default. This is a mutating admission controller that reviews all pod requests and adds tolerations to any pod that requests an extended resource advertised by a device plugin. For the NVIDIA GPU device plugin, it will automatically add the nvidia.com/gpu toleration to pods that request the nvidia.com/gpu resource, so you will not need to add this toleration explicitly for every GPU workload.
+====
 
 === Test a GPU Workload
 


### PR DESCRIPTION
In v5 skuba will enable the ExtendedResourceToleration admission
controller by default, so users will not have to manually enable it and
maintain it through upgrades. This patch removes these now-unnecessary
instructions, makes the discussion of the admission controller more
prominent, and adds further clarification on the effects of tainting
nodes.

# Related Issues / Projects
Please provide links to Bugzilla and other GitHub projects with your description if they are related to the changes.

Relates to: https://github.com/SUSE/avant-garde/issues/1699
RFC: https://github.com/SUSE/caasp-rfc/pull/62
Skuba PR: https://github.com/SUSE/skuba/pull/1192

<!--
# Make sure it's tested
*Technical writers will not always be able to verify the implementation!*

Any PR opened is assumed to have been verified by QA if not designated by comments or labels otherwise. Please make sure you have tested the changes and included any information that a user would require to use the documentation.

# Enable maintainer updates
Please enable maintainer updates so we can push commits into your branch to make collaboration and reviews easier.

# Do not force push your branch
Please avoid force pushing to branches that are subject of pull requests. Force pushing breaks maintainer commits in many cases and is very hard (if not impossible) to untangle for backporting.

# Labels
Please set any (and all) appropriate labels that describe the status of the PR.

| **Label** | **Description** |
| --- | --- |
| P1 | PR should be worked on and merged as soon as possible |
| Blocked | Work can not proceed because other work has not been completed, PR can not be merged (code has not been merged but documentation is ready) |
| On-Hold | Underlying work is completed but the PR should not be merged |
| ReleaseNotes | User interaction is required after the introduction of this change and the change must be mentioned in the release notes |
| v3/v4/v4.x | Which version of the release the PR should be merged into, this can be multiple versions, please set the "Backport" label if it needs to go into a previous release |
| Needs Review | Some details of the PR are known to be incomplete and must be discussed with other engineers before merging (if possible assign reviewers or cc mention in comments), PR can not be merged |
-->
