### PR TITLE
Fix duplicate word

### DIFF
--- a/adoc/admin-troubleshooting.adoc
+++ b/adoc/admin-troubleshooting.adoc
@@ -75,7 +75,7 @@ After opening a Service Request (SR), you can upload the `TAR` archive to {suse}
 
 == Log collection
 
-Some of these information are required for debugging certain cases. The data collected by
+Some of these information are required for debugging certain cases. The data collected
 via `supportconfig` in such cases are following:
 
 * etcd.txt (_master nodes_)


### PR DESCRIPTION
Fix duplicate word

here `by` and `via` have the same purpose