### PR TITLE
adoc: reflect cordon & drain operations on update

### DIFF
--- a/adoc/admin-updates.adoc
+++ b/adoc/admin-updates.adoc
@@ -259,6 +259,7 @@ The upgrade via `skuba node upgrade apply` will:
 
 * upgrade the containerized control plane.
 * upgrade the rest of the {kube} system stack (`kubelet`, `cri-o`).
+* temporarily drain/cordon the node before starting the whole process, and then undrain/uncordon the node after the upgrade has been successfully applied.
 * restart services.
 ====
 


### PR DESCRIPTION
# Describe your changes

When updating a node, skuba will cordon/drain the node before starting the operation, and it will uncordon/undrain it whenever the update has been applied successfully. This might not be expected by the user, so we better document it.

# Related Issues / Projects

See SUSE/doc-caasp#774
See SUSE/avant-garde#1842
See SUSE/skuba#1298