### PR TITLE
Add the possibility to co-install multiple kubectl versions

### DIFF
--- a/adoc/deployment-bootstrap.adoc
+++ b/adoc/deployment-bootstrap.adoc
@@ -798,3 +798,39 @@ kube-system   kured-zv696                             1/1       Running   0     
 kube-system   oidc-dex-55fc689dc-b9bxw                1/1       Running   0          2m
 kube-system   oidc-gangway-7b7fbbdbdf-ll6l8           1/1       Running   0          2m
 ----
+
+==== Co-installing multiple versions of kubectl
+
+It's possible to install multiple versions of `kubectl` on the same machine. In
+a {productname} management machine, you will be able to co-install multiple
+versions of `kubectl`, and later mark which is the version to be used with
+`update-alternatives` (by default with the highest version number will be selected).
+
+This can be useful, for example, when managing multiple Kubernetes clusters from
+the same {productname} management machine. That is, following {productname} 4.5,
+{productname} will be able to manage other (supported) Kubernetes versions than
+only 1.18.
+
+For example, in a system like this:
+
+[source,bash]
+----
+# kubectl version
+Client Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.6", GitCommit:"dff82dc0de47299ab66c83c626e08b245ab19037", GitTreeState:"clean", BuildDate:"2020-08-04T12:00:00Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
+Server Version: version.Info{Major:"1", Minor:"18", GitVersion:"v1.18.6", GitCommit:"dff82dc0de47299ab66c83c626e08b245ab19037", GitTreeState:"clean", BuildDate:"2020-08-04T12:00:00Z", GoVersion:"go1.13.15", Compiler:"gc", Platform:"linux/amd64"}
+----
+
+You can install another version and use other version previously installed with `update-alternatives`:
+
+[source,bash]
+----
+# zypper install kubernetes-1.19-client
+# update-alternatives --set kubectl /usr/bin/kubectl-1.18
+----
+
+At any time you can use newer version with `update-alternatives`:
+
+[source,bash]
+----
+# update-alternatives --set kubectl /usr/bin/kubectl-1.19
+----

--- a/adoc/deployment-openstack.adoc
+++ b/adoc/deployment-openstack.adoc
@@ -29,7 +29,9 @@ The {sls} {base_os_version} images for {soc} come with predefined user `sles`, w
 
 === Deploying the Cluster Nodes
 
-. Find the {tf} template files for {soc} in `/usr/share/caasp/terraform/openstack` (which was installed as part of the management pattern - `sudo zypper in -t pattern SUSE-CaaSP-Management`).
+. On the management machine, find the {tf} template files for {soc} in
+`/usr/share/caasp/terraform/openstack`. This files have been installed as part
+of the management pattern (`sudo zypper in -t pattern SUSE-CaaSP-Management`)
 Copy this folder to a location of your choice as the files need adjustment.
 +
 ----

--- a/adoc/deployment-preparation.adoc
+++ b/adoc/deployment-preparation.adoc
@@ -3,7 +3,7 @@
 
 In order to deploy {productname} you need a workstation running {sls} {base_os_version} or similar {opensuse} equivalent.
 This workstation is called the "Management machine". Important files are generated
-and must be maintained on this machine, but it is not a member of the {productname} cluster.
+and must be maintained on this machine, but it is *not* a member of the {productname} cluster.
 
 [#ssh-configuration]
 === Basic SSH Key Configuration

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -287,7 +287,7 @@ Name it reasonably so you can later identify the template. The template will be 
 
 . On the management machine, find the {tf} template files for {vmware} in
 `/usr/share/caasp/terraform/vmware`. This files have been installed as part of
-the management pattern (`sudo zypper in patterns-caasp-Management`).
+the management pattern (`sudo zypper in -t pattern SUSE-CaaSP-Management`).
 Copy this folder to a location of your choice; as the files need to be adjusted.
 +
 ----

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -392,7 +392,7 @@ the OS as needed.
 
 [TIP]
 ====
-To manually generate the unique `machine-id` please refer to: <<machine-id-regen>>.
+To manually generate the unique `machine-id` please refer to: [#machine-id-regen].
 ====
 
 === Container Runtime Proxy

--- a/adoc/deployment-vmware.adoc
+++ b/adoc/deployment-vmware.adoc
@@ -285,8 +285,9 @@ Name it reasonably so you can later identify the template. The template will be 
 
 ===== Using Terraform
 
-. Find the {tf} template files for {vmware} in `/usr/share/caasp/terraform/vmware` which was installed as part of the management
-pattern (`sudo zypper in patterns-caasp-Management`).
+. On the management machine, find the {tf} template files for {vmware} in
+`/usr/share/caasp/terraform/vmware`. This files have been installed as part of
+the management pattern (`sudo zypper in patterns-caasp-Management`).
 Copy this folder to a location of your choice; as the files need to be adjusted.
 +
 ----


### PR DESCRIPTION
# Describe your changes

Adds some documentation on the possibility to co-install multiple `kubectl` versions, plus some minor improvements (e.g. consistency on the management pattern being installed).

# Related Issues / Projects

SUSE/avant-garde#1878