### PR TITLE
Fix CaaSP version in Helm 2 to 3 Migration section

### DIFF
--- a/adoc/admin-software-installation.adoc
+++ b/adoc/admin-software-installation.adoc
@@ -222,7 +222,7 @@ The process for migrating an installation from Helm 2 to Helm 3 has been documen
 
 ==== Preconditions
 
-* A healthy CaaSP 5.0 installation with applications deployed using Helm 2 and Tiller.
+* A healthy CaaSP 4.5 installation with applications deployed using Helm 2 and Tiller.
 * A system, which `skuba` and `helm` version 2 have run on previously.
 ** The procedure below requires an available internet connection to install the `2to3` plugin.  If the installation is in an air gapped environment, the system may need to be moved back out of the air gapped environment.
 * These instructions are written for a single cluster managed from a single Helm 2 installation. If more than one cluster is being managed by this installation of Helm 2, please reference https://github.com/helm/helm-2to3 for further details and do not do the clean-up step until all clusters are migrated.
@@ -230,7 +230,7 @@ The process for migrating an installation from Helm 2 to Helm 3 has been documen
 
 ==== Migration Procedure
 
-This is a procedure for migrating a CaaSP 5.0 deployment that has used Helm 2 to deploy applications.
+This is a procedure for migrating a CaaSP 4.5 deployment that has used Helm 2 to deploy applications.
 
 . Install `helm3` package in the same location you normally run `skuba` commands (alongside the helm2 package):
 +


### PR DESCRIPTION
Fix version (4.5 instead of 5) in Helm 2 to 3 migration section

| **Label** | **Description** |
| --- | --- |
| v4.5 | Which version of the release the PR should be merged into, this can be multiple versions, please set the "Backport" label if it needs to go into a previous release |

