### PR TITLE
Add kubelet.conf warning message for k8s version < 1.17 (bsc#1176578)

### DIFF
--- a/adoc/admin-security-certificates.adoc
+++ b/adoc/admin-security-certificates.adoc
@@ -135,7 +135,7 @@ The control plane certificates stored in the {kube} cluster on control plane nod
 
 [WARNING]
 ====
-If the node is bootstrapped/joined prior to Kubernetes version 1.17, you have to manually modify the contents of `kubelet.conf` to point to the automatically rotated kubelet client certificates by replacing `client-certificate-data` and `client-key-data` with:
+If the node is bootstrapped/joined before Kubernetes version 1.17, you have to manually modify the contents of `kubelet.conf` to point to the automatically rotated kubelet client certificates by replacing `client-certificate-data` and `client-key-data` with:
 [source,bash]
 ----
 client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem

--- a/adoc/admin-security-certificates.adoc
+++ b/adoc/admin-security-certificates.adoc
@@ -135,7 +135,8 @@ The control plane certificates stored in the {kube} cluster on control plane nod
 
 [WARNING]
 ====
-If the node is bootstrapped/joined before Kubernetes version 1.17, you have to manually modify the contents of `kubelet.conf` to point to the automatically rotated kubelet client certificates by replacing `client-certificate-data` and `client-key-data` with:
+If a node was bootstrapped/joined before {kube} version 1.17, you have to manually modify the contents of `kubelet.conf` to point to the automatically rotated kubelet client certificates by replacing `client-certificate-data` and `client-key-data` with:
+
 [source,bash]
 ----
 client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem

--- a/adoc/admin-security-certificates.adoc
+++ b/adoc/admin-security-certificates.adoc
@@ -111,7 +111,37 @@ The control plane certificates stored in the {kube} cluster on control plane nod
 |front-proxy-ca
 |/etc/kubernetes/pki/front-proxy-client.crt,key
 |Client
+
+|kubernetes-admin
+|kubernetes
+|/etc/kubernetes/admin.conf
+|Client
+
+|system:kube-controller-manager
+|kubernetes
+|/etc/kubernetes/controller-manager.conf
+|Client
+
+|system:kube-scheduler
+|kubernetes
+|/etc/kubernetes/scheduler.conf
+|Client
+
+|system:node:<nodeName>
+|kubernetes
+|/etc/kubernetes/kubelet.conf
+|Client
 |===
+
+[WARNING]
+====
+If the node is bootstrapped/joined prior to Kubernetes version 1.17, you have to manually modify the contents of `kubelet.conf` to point to the automatically rotated kubelet client certificates by replacing `client-certificate-data` and `client-key-data` with:
+[source,bash]
+----
+client-certificate: /var/lib/kubelet/pki/kubelet-client-current.pem
+client-key: /var/lib/kubelet/pki/kubelet-client-current.pem
+----
+====
 
 The addon certificates stored in the {kube} cluster Secret resource:
 


### PR DESCRIPTION
# Describe your changes

The kubelet.conf has a bug if the node is bootstrapped/joined before
Kubernetes version < 1.17, the kubelet.conf did not point to the
automatically rotated kubelet client certificate.

Also, add the client certificate embedded in the KUBECONFIG files used
by kubeadm, which are
- admin.conf
- controller-manager.conf
- scheduler.conf
- kubelet.conf

# Related Issues / Projects

Relates to: bsc#1176578
xrefs to: https://github.com/SUSE/avant-garde/issues/1961

<!--
# Make sure it's tested
*Technical writers will not always be able to verify the implementation!*

Any PR opened is assumed to have been verified by QA if not designated by comments or labels otherwise. Please make sure you have tested the changes and included any information that a user would require to use the documentation.

# Enable maintainer updates
Please enable maintainer updates so we can push commits into your branch to make collaboration and reviews easier.

# Do not force push your branch
Please avoid force pushing to branches that are subject of pull requests. Force pushing breaks maintainer commits in many cases and is very hard (if not impossible) to untangle for backporting.

# Labels
Please set any (and all) appropriate labels that describe the status of the PR.

| **Label** | **Description** |
| --- | --- |
| P1 | PR should be worked on and merged as soon as possible |
| Blocked | Work can not proceed because other work has not been completed, PR can not be merged (code has not been merged but documentation is ready) |
| On-Hold | Underlying work is completed but the PR should not be merged |
| ReleaseNotes | User interaction is required after the introduction of this change and the change must be mentioned in the release notes |
| v3/v4/v4.x | Which version of the release the PR should be merged into, this can be multiple versions, please set the "Backport" label if it needs to go into a previous release |
| Needs Review | Some details of the PR are known to be incomplete and must be discussed with other engineers before merging (if possible assign reviewers or cc mention in comments), PR can not be merged |
-->
