### PR TITLE
Add documentation for Private Registry

### DIFF
--- a/adoc/book_registry-user.adoc
+++ b/adoc/book_registry-user.adoc
@@ -1,0 +1,29 @@
+include::attributes.adoc[]
+include::entities.adoc[]
+
+= {suse} Private Registry: User Guide
+:doctype: book
+:sectnums:
+:sectnumlevels: 4
+:toc: left
+:toclevels: 4
+:icons: font
+:revdate: 2020-10-19
+:imagesdir: images/
+:experimental:
+:docinfo: shared,private-head
+
+include::common_disclaimer.adoc[Disclaimer]
+
+include::common_copyright_quick.adoc[leveloffset=+1]
+
+include::registry-userguide.adoc[SUSE Private Registry: User Guide]
+
+// Change Log
+// include::common_changelog.adoc[Documentation Change Log]
+
+// Glossary for abbreviations and terms
+include::common_glossary.adoc[Glossary]
+
+//GNU Licenses
+include::common_legal.adoc[Legal]

--- a/adoc/book_registry.adoc
+++ b/adoc/book_registry.adoc
@@ -1,0 +1,29 @@
+include::attributes.adoc[]
+include::entities.adoc[]
+
+= {suse} Private Registry
+:doctype: book
+:sectnums:
+:sectnumlevels: 4
+:toc: left
+:toclevels: 4
+:icons: font
+:revdate: 2020-10-19
+:imagesdir: images/
+:experimental:
+:docinfo: shared,private-head
+
+include::common_disclaimer.adoc[Disclaimer]
+
+include::common_copyright_quick.adoc[leveloffset=+1]
+
+include::registry-intro.adoc[SUSE Private Registry Introduction]
+
+// Change Log
+// include::common_changelog.adoc[Documentation Change Log]
+
+// Glossary for abbreviations and terms
+include::common_glossary.adoc[Glossary]
+
+//GNU Licenses
+include::common_legal.adoc[Legal]

--- a/adoc/registry-admin.adoc
+++ b/adoc/registry-admin.adoc
@@ -1,0 +1,10 @@
+== Administration
+Setup Administration Access
+
+SUSE Private Registry User Interface can be accessed from a supported web browser at the location provided as <ingress_url> during the installation. Default password for admin user is Harbor12345.
+
+After the first login, you can change the administrator's password through the web UI: use "admin" tab and select "Change Password".
+
+Harbor supports different modes for authenticating users and managing user accounts. SUSE Private Registry Technical Preview currently supports only Database Authentication type, where the users are stored in the Harbor database. Read more about managing users in Database mode in the upstream documentation.
+
+// add screenshots

--- a/adoc/registry-deployment.adoc
+++ b/adoc/registry-deployment.adoc
@@ -1,0 +1,62 @@
+== Deployment
+
+=== Installation Steps
+
+    Add the SUSE Kubernetes Helm charts repository by running:
+
+helm repo add suse https://kubernetes-charts.suse.com
+
+2. Create a file harbor-config-values.yaml with the following content:
+harbor-config-values.yaml
+expose:
+  # Set the way how to expose the service. Default value is "ingress".
+  ingress:
+    hosts:
+      core: "<ingress_url>"
+
+# The external URL for Harbor core service. It is used to
+# 1) populate the docker/helm commands showed on portal
+# 2) populate the token service URL returned to docker/notary client
+#
+# Format: protocol://domain[:port]. Usually:
+# 1) if "expose.type" is "ingress", the "domain" should be
+# the value of "expose.ingress.hosts.core"
+#
+# If Harbor is deployed behind the proxy, set it as the URL of proxy
+externalURL: "https://<ingress_url>"
+
+
+Replace <ingress_url> with a URL that resolves to the ingress External IP.
+
+3. Review the SUSE EULA for Beta Software as available here: https://documentation.suse.com/beta/eula
+
+4. Install the Harbor helm chart from the new repository and provide the modified values that were created in previous step. For example, to install harbor as  suse-registry release into the registry namespace call
+kubectl create namespace registry
+helm install -n registry suse-registry suse/harbor  -f harbor-config-values.yaml --set suse.AcceptBetaEULA=yes
+
+Above example is for Helm v3. For Helm v2, the syntax of install command is slightly different
+helm install --namespace registry -n suse-registry suse/harbor  -f harbor-config-values.yaml --set suse.AcceptBetaEULA=yes
+
+Once the installation is complete, Helm will provide the information about the location of the newly installed registry, e.g.:
+NAME: suse-registry
+LAST DEPLOYED: Fri Jul 24 10:34:53 2020
+NAMESPACE: registry
+STATUS: deployed
+REVISION: 1
+NOTES:
+Please wait for several minutes for Harbor deployment to complete.
+Then you should be able to visit the Harbor portal at https://core.harbor.domain
+
+You will see your <ingress_url> instead of https://core.harbor.domain.
+
+5. Check the status of created pods and see if everything is running correctly:
+> kubectl -n registry get pod
+NAME                                                  READY   STATUS    RESTARTS   AGE
+suse-registry-harbor-core-c787885b6-2l7lz             1/1     Running   1          105m
+suse-registry-harbor-database-0                       1/1     Running   0          105m
+suse-registry-harbor-jobservice-698fb5bb44-88mc5      1/1     Running   1          105m
+suse-registry-harbor-nginx-b4f7748c5-8v2rp            1/1     Running   0          105m
+suse-registry-harbor-portal-bff5898cc-tt9ss           1/1     Running   0          105m
+suse-registry-harbor-redis-0                          1/1     Running   0          105m
+suse-registry-harbor-registry-7f65b6f87b-sqhzt        2/2     Running   0          105m
+suse-registry-harbor-trivy-0                          1/1     Running   0          105m

--- a/adoc/registry-features.adoc
+++ b/adoc/registry-features.adoc
@@ -1,0 +1,5 @@
+== Enabled Features
+
+The following table is a matrix listing the main features provided by Harbor, indicating those that are also enabled by the SUSE Private Registry Tech Preview release and are intended to become supported features for MVP. Please provide us feedback as early as possible on gaps or unrelevant features.
+
+// Add table

--- a/adoc/registry-intro.adoc
+++ b/adoc/registry-intro.adoc
@@ -1,0 +1,43 @@
+= Introduction
+
+This document covers the SUSE specifics around deployment and usage of SUSE Private Registry Technical Preview only.
+
+In general, the goal for the Technical Preview is to get feedback, so please share your feedback/requirements with the team (ecosystem@suse.de) instead of simply assuming that things will work or when they worked once will continue to work. We would like to assemble a list of popular requirements for the next release and work on strictly automated CI test automation for all mandatory features going forward.
+
+The next release of SUSE Private Registry, which will be supported with either CaaSP or CAP,  is currently scheduled for November 2020.
+
+== Requirements
+Kubernetes Distribution
+
+SUSE Private Registry Technical Preview must be deployed on top of  CaaSP v4.5.x or CaaSP v4.2.x. No other Kubernetes distribution is supported at the moment. Also, a deployment within CAP or a deployment outside CaaSP (like on bare-metal SLES) is not supported for the tech preview release.
+Helm
+
+SUSE Private Registry can only be deployed into the Kubernetes cluster via the Helm chart, Helm 3.2 or newer is a requirement.  Use https://software.opensuse.org/package/helm to find a build for your distribution.
+Storage Backend
+
+Prior deployment of SUSE Private Registry, Kubernetes cluster has to be configured so that it provides default storageClass for persistent storage. CaaSP 4.2 provides only very limited options of supported storageClass configurations, see the CaaSP documentation https://documentation.suse.com/suse-caasp/4.2/html/caasp-admin/_storage.html for details.
+Ingress
+
+The default way of installing Harbor using the helm chart needs an Ingress service to expose the Harbor service. The Kubernetes cluster where the chart is being deployed needs to have an ingress controller enabled. Check for example how to deploy Nginx based Ingress controller with CaaSP.
+
+== Limitations
+
+Tech Preview was focusing on the core areas and had a limited scope, so not all deployment options available in the Helm chart have been tested. Specifically public cloud based CaaSP deployments have had limited testing.
+
+The provided helm chart does not deploy in a High Availability configuration.
+
+There is no supported upgrade path from Tech Preview to the next release of SUSE Private Registry in November. Although we strive for an in-place upgrade to MVP release, we use this upgrade to MVP as a learning exercise.
+
+Accuracy of the Image scanning using Trivy might be limited.
+
+Neither Notary nor podman/gpg signing is supported.
+
+There is no integration with CAP, like UAA, currently supported.
+
+== Highlights
+
+Customers that want to follow a Cloud Native Application Development and Delivery need at the heart of the delivery a Registry and a CI/CD instance to simplify the development and production of container images. SUSE Private Registry provides such a  Registry solution, which help developers to store, manage and deploy different artifacts. The SUSE Private Registry solution gives the development team a place to manage the container images, control the access, and do vulnerability scanning.
+
+SUSE Private Registry is a fully OCI compliant container image registry solution and includes additionally a Harbor based UI . Harbor allows users to configure storage, replication and provides with fine grained access control on both OCI container images and Helm charts. It's based on SUSE Linux Enterprise, using only official SUSE images.
+
+Harbor is an open source registry that secures artifacts with policies and role-based access control, ensures images are scanned and free from vulnerabilities, and signs images as trusted. Harbor, a CNCF Graduated project, delivers compliance, performance, and interoperability to help you consistently and securely manage artifacts across cloud native compute platforms like Kubernetes and Docker. For extensive documentation, please look at the upstream documentation: https://goharbor.io/docs/2.0.0/

--- a/adoc/registry-scenarios.adoc
+++ b/adoc/registry-scenarios.adoc
@@ -1,0 +1,5 @@
+== Supported Deployment Options
+
+The following table is a matrix listing the Helm chart deployment options provided by Harbor, indicating those that are also supported by the SUSE Private Registry Tech Preview release.
+
+// Add table

--- a/adoc/registry-troubleshooting.adoc
+++ b/adoc/registry-troubleshooting.adoc
@@ -1,0 +1,14 @@
+== Troubleshooting
+
+The installation using Helm is fully automated and should succeed when the requirements are met. After a few seconds, the ingress controller configured path should be responding with the login screen of an admin UI, see the   "Documentation - Technical Preview release#Administration" section.
+
+In case of issues, please make sure all pods in registry namespace are running and all deployments are in the Ready state. If a pod fails to start, investigate the situation with your debugging tool of choice. (k9s, or kubectl).
+
+Private registry deploys in the given kubernetes namespace multiple deployments and one statefulset, and all of them should be healthy.
+
+Possible problems:
+
+    As mentioned in the requirements, ingress-controller needs to be set up in your kubernetes cluster
+    When accessing the Web UI, browser complains about unknown certificate. Check the TLS Setup section for a solution.
+    Images for various SUSE Private Registry components cannot be found, and Pods are not getting created. Make sure registry.suse.com is accessible from your network.
+    Pods are not starting, most of them fail with failed to connect to database pod error. Check the errors in the database pod. Does it complain with something like FailedScheduling <unknown> default-scheduler pod has unbound immediate PersistentVolumeClaims (repeated 2 times)? Possible reason is that the storageClass is missing or no storageClass is marked as default

--- a/adoc/registry-userguide.adoc
+++ b/adoc/registry-userguide.adoc
@@ -1,0 +1,105 @@
+== User Guide
+// Add screenshots
+
+Accessing Landing Page
+
+After logging in, a harbor installation lands on the Projects page. Project pages are the individual "tenants" or "organisations" that the SUSE Private Registry can host. For each one of those, Access Control, Security Policies, Webhooks or Accounts can be defined. Access (push/pull) and other event logs can be accessed. A Project can be populated by replicating another registry, like for example registry.suse.com. Here's how an example harbor installation with mirroring itself from registry.suse.com would look like:
+
+Using docker for managing images
+
+Assume there's a hello-world image in your current local docker registry:
+> docker images
+REPOSITORY                                                                        TAG                  IMAGE ID            CREATED             SIZE
+hello-world                                                                       latest               bf756fb1ae65        6 months ago        13.3kB
+
+Let's assume the value of <ingress_url> is core.harbor.domain.
+
+Log in to new Harbor based Docker registry:
+docker login core.harbor.domain -u admin
+
+Tag an existing image:
+docker tag hello-world core.harbor.domain/library/hello-world:latest
+
+Note the "library" part. That's a project you will be pushing the image to. Look how to manage projects in the upstream documentation.
+
+Push the image to your Harbor registry:
+> docker push core.harbor.domain/library/hello-world:latest
+The push refers to repository [core.harbor.domain/library/hello-world]
+9c27e219663c: Pushed
+latest: digest: sha256:90659bf80b44ce6be8234e6ff90a1ac34acbeb826903b02cfa0da11c82cbc042 size: 525
+
+Now go to Harbor web UI and you can see the new image is stored under library project as library/hello-world
+Manage Helm Charts with SUSE Private Registry
+
+Helm Charts in SUSE Private Registry requires Helm v3, which is not offered by SUSE CaaSP 4.2.  Helm v3 is a client only solution so you only need it on the machine that you launch the installation from. You can use the helm client from openSUSE Kubic packages or the upstream Helm release and it works just fine on a CaaSP 4.2 cluster. In order to use helm, you need to Log into OCI-compatible registry of Harbor:
+
+
+> helm registry login core.harbor.domain
+Username: admin
+Password:
+Login succeeded
+
+After logging in, run the helm chart save command to save a chart directory that prepares the artifact for pushing:
+
+
+helm chart save my-chart core.harbor.domain/library/my-chart
+
+Now you can push the chart to the Private Registry:
+
+
+helm chart push core.harbor.domain/library/my-chart:version
+
+Go to the Helm web UI and you can see the chart located under library project.
+
+Read more in the upstream documentation.
+Using SUSE Private Registry in the Kubernetes Cluster
+
+You can set up your Kubernetes Cluster to use your newly deployed SUSE Private Registry as a source of Images. Read more about using SUSE Private Registry for Kubernetes cluster. Following setup is based on Specifying ImagePullSecrets on a Pod section.
+
+Copy your generated CA certificate to all nodes of kubernetes cluster so that container daemons trust it when pulling images from the private registry. It's possible to install them to the configuration directory specific to the container engine you are using, e.g. /etc/docker/certs.d/ for docker.
+
+Or copy them system-wide - repeat this for all your Kubernetes nodes:
+scp harbor.ca root@$kubernetes_node:
+ssh root@$kubernetes.node
+cp harbor.ca /usr/share/pki/trust/anchors/
+update-ca-certificates
+systemctl restart crio
+
+Notice that example above is restarting crio service which is the container engine used by CaaSP.
+
+Create a Secret of docker-registry type. Use the right own values for docker-server and docker-password, so that they match your environment:
+kubectl create secret docker-registry registrycred --docker-server=core.harbor.domain --docker-username=admin --docker-password=Harbor12345
+
+Now, you can create pods which reference newly created registrycred secret by adding an imagePullSecrets section to a Pod definition. Like this:
+pod example
+apiVersion: v1
+kind: Pod
+metadata:
+  name: foo
+spec:
+  containers:
+  - name: foo
+    image: core.harbor.domain/library/hello-world:latest
+  imagePullSecrets:
+  - name: registrycred
+
+Save the code above into some yaml file, e.g. hello-pod.yaml and create the new pod that pulls the image from your private registry:
+kubectl apply -f hello-pod.yaml
+
+Note: It is possible to add ImagePullSecrets to a service account, so it is not necessary to pass it to each Pod. Read about it in upstream documentation.
+Vulnerability Scanning
+
+SUSE Private Registry provides static analysis of vulnerabilities in images through the Open Source project Trivy. No other scanners are supported with the Technical Preview.
+
+Trivy is enabled by default when deploying the Helm chart and can be disabled by editing the values.yaml before deployment:
+values.yaml
+trivy:
+  # enabled the flag to enable Trivy scanner
+  enabled: true
+
+Log in to the Harbor interface with an account that has at least project administrator privileges. To see the vulnerabilities detected in repository artifacts, click the Repositories tab and then click on a repository. For each artifact in the repository, the Vulnerabilities column displays the vulnerability scanning status and related information.
+
+
+To run a vulnerability scan, select the artifacts to scan and then click the Scan button. You can optionally select the checkbox at the top to select all artifacts in the repository.
+
+Read more about vulnerability scanning in the upstream documentation.


### PR DESCRIPTION
# Describe your changes
Adds docs for SUSE Private (Container) Registry

Content from: https://confluence.suse.com/display/ENGCTNRSTORY/Documentation+-+SUSE+Private+Registry+Powered+by+Harbor+2.1

Creates two new documents:
Private Registry Documentation (Introduction, Deployment, Administration)
Private Registry User Guide

# Related Issues / Projects
Please provide links to Bugzilla and other GitHub projects with your description if they are related to the changes.

Relates to: https://github.com/SUSE/avant-garde/issues/1945